### PR TITLE
Make /ccheatcrackrng return old seed if existent for testing

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/command/CheatCrackRNGCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CheatCrackRNGCommand.java
@@ -1,12 +1,14 @@
 package net.earthcomputer.clientcommands.command;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.earthcomputer.clientcommands.TempRules;
 import net.earthcomputer.clientcommands.features.PlayerRandCracker;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.TranslatableText;
 
-import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
-import static net.minecraft.server.command.CommandManager.*;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.addClientSideCommand;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.sendFeedback;
+import static net.minecraft.server.command.CommandManager.literal;
 
 public class CheatCrackRNGCommand {
 
@@ -18,8 +20,15 @@ public class CheatCrackRNGCommand {
     }
 
     private static int crackPlayerRNG(ServerCommandSource source) {
-        long seed = PlayerRandCracker.singlePlayerCrackRNG();
-        sendFeedback(new TranslatableText("commands.ccrackrng.success", Long.toHexString(seed)));
+        long seed;
+        if (TempRules.playerCrackState.knowsSeed()) {
+            long oldSeed = PlayerRandCracker.getSeed();
+            seed = PlayerRandCracker.singlePlayerCrackRNG();
+            sendFeedback(new TranslatableText("commands.ccheatcrackrng.success", Long.toHexString(oldSeed), Long.toHexString(seed)));
+        } else {
+            seed = PlayerRandCracker.singlePlayerCrackRNG();
+            sendFeedback(new TranslatableText("commands.ccrackrng.success", Long.toHexString(seed)));
+        }
         return (int) seed;
     }
 

--- a/src/main/resources/assets/clientcommands/lang/de_de.json
+++ b/src/main/resources/assets/clientcommands/lang/de_de.json
@@ -6,6 +6,7 @@
 
   "commands.ccrackrng.starting": "Spielerseed knacken",
   "commands.ccrackrng.success": "Spieler-RNG geknackt: %d",
+  "commands.ccheatcrackrng.success": "Spieler-RNG geknackt: %d -> %d",
 
   "commands.cenchant.expectedWithWithout": "\"with\"/\"without\" erwartet",
   "commands.cenchant.failed": "Es ist unmöglich oder würde zu lange brauchen, diese Verzauberungen zu bekommen",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -12,6 +12,7 @@
 
   "commands.ccrackrng.starting": "Cracking player seed",
   "commands.ccrackrng.success": "Player RNG cracked: %d",
+  "commands.ccheatcrackrng.success": "Player RNG cracked: %d -> %d",
 
   "commands.cenchant.expectedWithWithout": "Expected \"with\"/\"without\"",
   "commands.cenchant.failed": "It's impossible or would take too long to get those enchantments",

--- a/src/main/resources/assets/clientcommands/lang/pl_pl.json
+++ b/src/main/resources/assets/clientcommands/lang/pl_pl.json
@@ -12,6 +12,7 @@
 
   "commands.ccrackrng.starting": "Łamanie ziarna gracza",
   "commands.ccrackrng.success": "RNG gracza złamane: %d",
+  "commands.ccheatcrackrng.success": "RNG gracza złamane: %d -> %d",
 
   "commands.cenchant.expectedWithWithout": "Spodziewane \"with\"/\"without\"",
   "commands.cenchant.failed": "To niemożliwe albo zajmie to zbyt długo aby otzymać te zaklęcia",

--- a/src/main/resources/assets/clientcommands/lang/sl_si.json
+++ b/src/main/resources/assets/clientcommands/lang/sl_si.json
@@ -6,7 +6,8 @@
   
     "commands.ccrackrng.starting": "Ugotavljanje semena igralca",
     "commands.ccrackrng.success": "RNG seme igralca uspešno ugotovljeno: %d",
-  
+    "commands.ccheatcrackrng.success": "RNG seme igralca uspešno ugotovljeno: %d -> %d",
+
     "commands.cenchant.expectedWithWithout": "Pričakovano \"z\"/\"brez\"",
     "commands.cenchant.failed": "Nemogoče je ali bi trajalo pre dolgo, da bi dobile te čare",
     "commands.cenchant.incompatible": "Nezdružljivi čari",

--- a/src/main/resources/assets/clientcommands/lang/zh_cn.json
+++ b/src/main/resources/assets/clientcommands/lang/zh_cn.json
@@ -12,6 +12,7 @@
 
   "commands.ccrackrng.starting": "正在破解玩家随机种子",
   "commands.ccrackrng.success": "玩家随机种子已破解： %d",
+  "commands.ccheatcrackrng.success": "玩家随机种子已破解： %d -> %d",
 
   "commands.cenchant.expectedWithWithout": "有效参数： \"with\" 或 \"without\"",
   "commands.cenchant.failed": "您请求的附魔无法获得或者需要太长时间",


### PR DESCRIPTION
Makes /ccheatcrackrng print "Player RNG cracked: %oldSeed% -> %newCheatCrackedSeed%" 
This is useful for testing rng advancement.