### PR TITLE
Updated /cglow to allow blocks and areas to be highlighted

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/command/ClientCommandManager.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/ClientCommandManager.java
@@ -99,17 +99,22 @@ public class ClientCommandManager {
         return 1;
     }
 
-    public static Text getCoordsTextComponent(BlockPos pos) {
-        return new TranslatableText("commands.client.blockpos", pos.getX(), pos.getY(), pos.getZ()).styled(style -> style
-                .withFormatting(Formatting.UNDERLINE)
-                .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND,
-                        String.format("/clook block %d %d %d", pos.getX(), pos.getY(), pos.getZ())))
-                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                        new LiteralText(String.format("/clook block %d %d %d", pos.getX(), pos.getY(), pos.getZ())))));
+    public static Text getLookCoordsTextComponent(BlockPos pos) {
+        return getCommandTextComponent(new TranslatableText("commands.client.blockpos", pos.getX(), pos.getY(), pos.getZ()),
+                String.format("/clook block %d %d %d", pos.getX(), pos.getY(), pos.getZ()));
+    }
+
+    public static Text getGlowCoordsTextComponent(BlockPos pos) {
+        return getCommandTextComponent(new TranslatableText("commands.client.blockpos", pos.getX(), pos.getY(), pos.getZ()),
+                String.format("/cglow block %d %d %d 10", pos.getX(), pos.getY(), pos.getZ()));
     }
 
     public static Text getCommandTextComponent(String translationKey, String command) {
-        return new TranslatableText(translationKey).styled(style -> style.withFormatting(Formatting.UNDERLINE)
+        return getCommandTextComponent(new TranslatableText(translationKey), command);
+    }
+
+    public static Text getCommandTextComponent(TranslatableText translatableText, String command) {
+        return translatableText.styled(style -> style.withFormatting(Formatting.UNDERLINE)
                 .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command))
                 .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText(command))));
     }

--- a/src/main/java/net/earthcomputer/clientcommands/command/FindBlockCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FindBlockCommand.java
@@ -62,7 +62,7 @@ public class FindBlockCommand {
         } else {
             double foundRadius = radiusType.distanceFunc.applyAsDouble(closestBlock.subtract(origin));
             sendFeedback(new TranslatableText("commands.cfindblock.success.left", foundRadius)
-                    .append(getCoordsTextComponent(closestBlock))
+                    .append(getGlowCoordsTextComponent(closestBlock))
                     .append(new TranslatableText("commands.cfindblock.success.right", foundRadius)));
             return 1;
         }

--- a/src/main/java/net/earthcomputer/clientcommands/command/FindCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FindCommand.java
@@ -65,7 +65,7 @@ public class FindCommand {
     private static void sendEntityFoundMessage(ServerCommandSource source, Entity entity) {
         double distance = Math.sqrt(entity.squaredDistanceTo(source.getPosition()));
         sendFeedback(new TranslatableText("commands.cfind.found.left", entity.getName(), distance)
-                .append(getCoordsTextComponent(entity.getBlockPos()))
+                .append(getLookCoordsTextComponent(entity.getBlockPos()))
                 .append(new TranslatableText("commands.cfind.found.right", entity.getName(), distance)));
     }
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/FindItemCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FindItemCommand.java
@@ -226,7 +226,7 @@ public class FindItemCommand {
                             }
                             if (matchingItems > 0) {
                                 sendFeedback(new TranslatableText("commands.cfinditem.match.left", matchingItems, searchingForName)
-                                        .append(getCoordsTextComponent(currentlySearching))
+                                        .append(getLookCoordsTextComponent(currentlySearching))
                                         .append(new TranslatableText("commands.cfinditem.match.right", matchingItems, searchingForName)));
                                 totalFound += matchingItems;
                             }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinGameRenderer.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinGameRenderer.java
@@ -2,6 +2,7 @@ package net.earthcomputer.clientcommands.mixin;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.earthcomputer.clientcommands.render.RenderQueue;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.BufferBuilderStorage;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.GameRenderer;
@@ -22,11 +23,16 @@ public abstract class MixinGameRenderer {
     @Inject(method = "renderWorld", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiler/Profiler;swap(Ljava/lang/String;)V", args = {"ldc=hand"}))
     private void renderWorldHand(float delta, long time, MatrixStack matrixStack, CallbackInfo ci) {
         matrixStack.push();
+
+        //Render lines through everything
+        RenderSystem.clear(256, MinecraftClient.IS_SYSTEM_MAC);
+
         Vec3d cameraPos = camera.getPos();
         matrixStack.translate(-cameraPos.x, -cameraPos.y, -cameraPos.z);
         RenderSystem.disableDepthTest();
         RenderQueue.render(RenderQueue.Layer.ON_TOP, matrixStack, buffers.getEntityVertexConsumers(), delta);
         RenderSystem.enableDepthTest();
+
         matrixStack.pop();
     }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinGameRenderer.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinGameRenderer.java
@@ -8,6 +8,7 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Vec3d;
+import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -24,8 +25,9 @@ public abstract class MixinGameRenderer {
     private void renderWorldHand(float delta, long time, MatrixStack matrixStack, CallbackInfo ci) {
         matrixStack.push();
 
-        //Render lines through everything
-        RenderSystem.clear(256, MinecraftClient.IS_SYSTEM_MAC);
+        // Render lines through everything
+        // TODO: is this the best approach to render through blocks?
+        RenderSystem.clear(GL11.GL_DEPTH_BUFFER_BIT, MinecraftClient.IS_SYSTEM_MAC);
 
         Vec3d cameraPos = camera.getPos();
         matrixStack.translate(-cameraPos.x, -cameraPos.y, -cameraPos.z);

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -56,9 +56,10 @@
   "commands.cgive.success": "Gave %d %s to self",
   "commands.cgive.notCreative": "Player must be in creative mode to give items to self",
 
-  "commands.cglow.keepSearching.success": "Glowing entities.",
-  "commands.cglow.failed": "No entities to glow",
-  "commands.cglow.success": "Glowing %d entities",
+  "commands.cglow.entity.keepSearching.success": "Glowing entities.",
+  "commands.cglow.entity.failed": "No entities to glow",
+  "commands.cglow.entity.success": "Glowing %d entities",
+  "commands.cglow.area.success": "Glowing %d area(s)",
 
   "commands.cplaysound.success": "Played sound %s to self",
 


### PR DESCRIPTION
The title says it...

I'm unsure about two things:
* Whether `MinecraftClient.getInstance().world` (GlowCommand.java, L130)
  is the right way to get the world in the command context.
* My "fix" in order to allow rendering through blocks is right (MixinGameRenderer.java, L28)  
   `RenderSystem.clear(256, MinecraftClient.IS_SYSTEM_MAC);`

I intentionally didn't add the ability to use a `--keep-searching` flag to `/cglow blocks` and made the input only coordinates,  
since there is already a command, that finds blocks for somebody named `/cfindblock`.

I instead made the output of `/cfindblock` "glowable" instead of "lookable."  
One could also add a flag to `/cfindblock` to automatically glow the found block...
