### PR TITLE
Allow for namespaced commands and move commands to a separate package

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -1,9 +1,8 @@
 package net.earthcomputer.clientcommands;
 
 import com.mojang.brigadier.CommandDispatcher;
-import net.earthcomputer.clientcommands.command.*;
-import net.earthcomputer.clientcommands.features.ChorusManipulation;
-import net.earthcomputer.clientcommands.render.RenderQueue;
+import net.earthcomputer.clientcommands.command.ClientCommandManager;
+import net.earthcomputer.clientcommands.command.commands.*;
 import net.earthcomputer.clientcommands.script.ScriptManager;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;

--- a/src/main/java/net/earthcomputer/clientcommands/command/CommandReader.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CommandReader.java
@@ -1,0 +1,26 @@
+package net.earthcomputer.clientcommands.command;
+
+import com.mojang.brigadier.StringReader;
+
+public class CommandReader extends StringReader {
+    public CommandReader(String command) {
+        super(command);
+    }
+
+    public String readUnquotedString() {
+        final int start = super.getCursor();
+        while (super.canRead() && isAllowedInCommand(super.peek())) {
+            super.skip();
+        }
+        return super.getString().substring(start, super.getCursor());
+    }
+
+    public static boolean isAllowedInCommand(final char c) {
+        return c >= '0' && c <= '9'
+                || c >= 'A' && c <= 'Z'
+                || c >= 'a' && c <= 'z'
+                || c == '_' || c == '-'
+                || c == '.' || c == '+'
+                || c == ':';
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/BookCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/BookCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CEnchantCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CEnchantCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.LiteralCommandNode;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CGiveCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CGiveCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import static com.mojang.brigadier.arguments.IntegerArgumentType.*;
 import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CHelpCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CHelpCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.google.common.collect.Iterables;
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CPlaySoundCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CPlaySoundCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import static com.mojang.brigadier.arguments.FloatArgumentType.*;
 import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CStopSoundCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CStopSoundCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
 import static net.minecraft.command.argument.IdentifierArgumentType.*;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CalcCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CalcCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.earthcomputer.clientcommands.TempRules;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CalcStackCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CalcStackCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CheatCrackRNGCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CheatCrackRNGCommand.java
@@ -1,8 +1,6 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
-import net.cortex.clientAddon.cracker.SeedCracker;
-import net.earthcomputer.clientcommands.ServerBrandManager;
 import net.earthcomputer.clientcommands.TempRules;
 import net.earthcomputer.clientcommands.features.PlayerRandCracker;
 import net.minecraft.server.command.ServerCommandSource;
@@ -12,23 +10,26 @@ import static net.earthcomputer.clientcommands.command.ClientCommandManager.addC
 import static net.earthcomputer.clientcommands.command.ClientCommandManager.sendFeedback;
 import static net.minecraft.server.command.CommandManager.literal;
 
-public class CrackRNGCommand {
+public class CheatCrackRNGCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        addClientSideCommand("ccrackrng");
+        addClientSideCommand("ccheatcrackrng");
 
-        dispatcher.register(literal("ccrackrng")
+        dispatcher.register(literal("ccheatcrackrng")
             .executes(ctx -> crackPlayerRNG(ctx.getSource())));
     }
 
     private static int crackPlayerRNG(ServerCommandSource source) {
-        ServerBrandManager.rngWarning();
-        SeedCracker.crack(seed -> {
+        long seed;
+        if (TempRules.playerCrackState.knowsSeed()) {
+            long oldSeed = PlayerRandCracker.getSeed();
+            seed = PlayerRandCracker.singlePlayerCrackRNG();
+            sendFeedback(new TranslatableText("commands.ccheatcrackrng.success", Long.toHexString(oldSeed), Long.toHexString(seed)));
+        } else {
+            seed = PlayerRandCracker.singlePlayerCrackRNG();
             sendFeedback(new TranslatableText("commands.ccrackrng.success", Long.toHexString(seed)));
-            PlayerRandCracker.setSeed(seed);
-            TempRules.playerCrackState = PlayerRandCracker.CrackState.CRACKED;
-        });
-        return 0;
+        }
+        return (int) seed;
     }
 
 }

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/ChorusCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/ChorusCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/CrackRNGCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/CrackRNGCommand.java
@@ -1,6 +1,8 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.cortex.clientAddon.cracker.SeedCracker;
+import net.earthcomputer.clientcommands.ServerBrandManager;
 import net.earthcomputer.clientcommands.TempRules;
 import net.earthcomputer.clientcommands.features.PlayerRandCracker;
 import net.minecraft.server.command.ServerCommandSource;
@@ -10,26 +12,23 @@ import static net.earthcomputer.clientcommands.command.ClientCommandManager.addC
 import static net.earthcomputer.clientcommands.command.ClientCommandManager.sendFeedback;
 import static net.minecraft.server.command.CommandManager.literal;
 
-public class CheatCrackRNGCommand {
+public class CrackRNGCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        addClientSideCommand("ccheatcrackrng");
+        addClientSideCommand("ccrackrng");
 
-        dispatcher.register(literal("ccheatcrackrng")
+        dispatcher.register(literal("ccrackrng")
             .executes(ctx -> crackPlayerRNG(ctx.getSource())));
     }
 
     private static int crackPlayerRNG(ServerCommandSource source) {
-        long seed;
-        if (TempRules.playerCrackState.knowsSeed()) {
-            long oldSeed = PlayerRandCracker.getSeed();
-            seed = PlayerRandCracker.singlePlayerCrackRNG();
-            sendFeedback(new TranslatableText("commands.ccheatcrackrng.success", Long.toHexString(oldSeed), Long.toHexString(seed)));
-        } else {
-            seed = PlayerRandCracker.singlePlayerCrackRNG();
+        ServerBrandManager.rngWarning();
+        SeedCracker.crack(seed -> {
             sendFeedback(new TranslatableText("commands.ccrackrng.success", Long.toHexString(seed)));
-        }
-        return (int) seed;
+            PlayerRandCracker.setSeed(seed);
+            TempRules.playerCrackState = PlayerRandCracker.CrackState.CRACKED;
+        });
+        return 0;
     }
 
 }

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/FindBlockCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/FindBlockCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.block.pattern.CachedBlockPosition;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/FindCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/FindCommand.java
@@ -1,7 +1,9 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import net.earthcomputer.clientcommands.command.ClientEntitySelector;
+import net.earthcomputer.clientcommands.command.FakeCommandSource;
 import net.earthcomputer.clientcommands.task.LongTask;
 import net.earthcomputer.clientcommands.task.TaskManager;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/FindItemCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/FindItemCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/FishCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/FishCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.google.common.collect.ImmutableSet;
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/GammaCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/GammaCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/GetDataCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/GetDataCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.google.common.collect.ImmutableList;
 import com.mojang.brigadier.CommandDispatcher;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/GhostBlockCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/GhostBlockCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/GlowCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/GlowCommand.java
@@ -1,9 +1,11 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+import net.earthcomputer.clientcommands.command.ClientEntitySelector;
+import net.earthcomputer.clientcommands.command.FakeCommandSource;
 import net.earthcomputer.clientcommands.interfaces.IEntity;
 import net.earthcomputer.clientcommands.render.RenderQueue;
 import net.earthcomputer.clientcommands.task.SimpleTask;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/LookCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/LookCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/MoteCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/MoteCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/NoteCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/NoteCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/RelogCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/RelogCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/RenderCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/RenderCommand.java
@@ -1,6 +1,7 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
+import net.earthcomputer.clientcommands.command.ClientEntitySelector;
 import net.earthcomputer.clientcommands.features.RenderSettings;
 import net.minecraft.server.command.ServerCommandSource;
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/ScriptCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/ScriptCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/ShrugCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/ShrugCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.client.MinecraftClient;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/SignSearchCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/SignSearchCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.block.AbstractSignBlock;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/TaskCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/TaskCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.earthcomputer.clientcommands.task.TaskManager;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/TempRuleCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/TempRuleCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.ArgumentBuilder;

--- a/src/main/java/net/earthcomputer/clientcommands/command/commands/WikiCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/commands/WikiCommand.java
@@ -1,4 +1,4 @@
-package net.earthcomputer.clientcommands.command;
+package net.earthcomputer.clientcommands.command.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import net.earthcomputer.clientcommands.features.WikiRetriever;

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientPlayerEntity.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientPlayerEntity.java
@@ -1,8 +1,8 @@
 package net.earthcomputer.clientcommands.mixin;
 
 import com.mojang.authlib.GameProfile;
-import com.mojang.brigadier.StringReader;
 import net.earthcomputer.clientcommands.command.ClientCommandManager;
+import net.earthcomputer.clientcommands.command.CommandReader;
 import net.earthcomputer.clientcommands.features.PlayerRandCracker;
 import net.earthcomputer.clientcommands.interfaces.IKeyBinding;
 import net.earthcomputer.clientcommands.script.ScriptManager;
@@ -37,7 +37,7 @@ public class MixinClientPlayerEntity extends AbstractClientPlayerEntity {
     @Inject(method = "sendChatMessage", at = @At("HEAD"), cancellable = true)
     private void onSendChatMessage(String message, CallbackInfo ci) {
         if (message.startsWith("/")) {
-            StringReader reader = new StringReader(message);
+            CommandReader reader = new CommandReader(message);
             reader.skip();
             int cursor = reader.getCursor();
             String commandName = reader.canRead() ? reader.readUnquotedString() : "";


### PR DESCRIPTION
By using `reader.readUnquotedString()` to parse the string, commands cannot contain `:`. By allowing commands with `:`, one can create pseudo namespaced commands (vanilla Minecraft does not support properly namespaced commands). This can be useful to prevent conflicts between client-sided and server-sided literals.
I chose not to Mixin `StringReader` and change the method because that could have unwanted side-effects. For this reason I created a subclass of `StringReader`, which inherits everything from `StringReader` but the regarding method.

Furthermore, I moved all the commands to a new package: `command.commands`, which makes the file structure a lot more clear. Before, classes like `ClientCommandManager` were hard to find as they were a needle in a haystack of command classes.

Any suggestions are welcome.