### PR TITLE
Add the cfov command

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -55,6 +55,7 @@ public class ClientCommands implements ClientModInitializer {
         CGiveCommand.register(dispatcher);
         CPlaySoundCommand.register(dispatcher);
         CStopSoundCommand.register(dispatcher);
+        FovCommand.register(dispatcher);
 
         CrackRNGCommand.register(dispatcher);
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/FovCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FovCommand.java
@@ -18,14 +18,14 @@ public class FovCommand {
 
         dispatcher.register(literal("cfov")
             .then(argument("fov", doubleArg())
-                .executes(ctx -> setGamma(ctx.getSource(), getDouble(ctx, "fov"))))
+                .executes(ctx -> setFov(ctx.getSource(), getDouble(ctx, "fov"))))
             .then(literal("normal")
-                .executes(ctx -> setGamma(ctx.getSource(), 70)))
+                .executes(ctx -> setFov(ctx.getSource(), 70)))
             .then(literal("quakePro")
-                .executes(ctx -> setGamma(ctx.getSource(), 110))));
+                .executes(ctx -> setFov(ctx.getSource(), 110))));
     }
 
-    private static int setGamma(ServerCommandSource source, double fov) {
+    private static int setFov(ServerCommandSource source, double fov) {
         MinecraftClient.getInstance().options.fov = fov;
 
         Text feedback = new TranslatableText("commands.cfov.success", fov);

--- a/src/main/java/net/earthcomputer/clientcommands/command/FovCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FovCommand.java
@@ -1,0 +1,37 @@
+package net.earthcomputer.clientcommands.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+
+import static com.mojang.brigadier.arguments.DoubleArgumentType.*;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
+import static net.minecraft.server.command.CommandManager.*;
+
+public class FovCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        addClientSideCommand("cfov");
+
+        dispatcher.register(literal("cfov")
+            .then(argument("fov", doubleArg())
+                .executes(ctx -> setGamma(ctx.getSource(), getDouble(ctx, "fov"))))
+            .then(literal("normal")
+                .executes(ctx -> setGamma(ctx.getSource(), 70)))
+            .then(literal("quakePro")
+                .executes(ctx -> setGamma(ctx.getSource(), 110))));
+    }
+
+    private static int setGamma(ServerCommandSource source, double fov) {
+        MinecraftClient.getInstance().options.fov = fov;
+
+        Text feedback = new TranslatableText("commands.cfov.success", fov);
+        sendFeedback(feedback);
+
+        return 0;
+    }
+
+}

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -49,6 +49,8 @@
   "commands.cfish.removeGoal.success": "Successfully removed goal %s",
   "commands.cfish.wrongLoot": "Didn't get the correct loot with correction of %dms, could have been %s ticks ahead",
 
+  "commands.cfov.success": "Set FOV to %f",
+
   "commands.cgamma.success": "Set gamma to %f",
 
   "commands.cghostblock.fill.success": "%d ghost blocks filled",


### PR DESCRIPTION
This pull request fixes #203 by adding the `/cfov` command. This command allows setting the FOV to any double value, in addition to the vanilla presets, `normal` (70) and `quakePro` (110).