### PR TITLE
Greatly improve efficiency of IO

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -6,13 +6,9 @@ import net.earthcomputer.clientcommands.script.ScriptManager;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.resource.language.I18n;
 import net.minecraft.server.command.ServerCommandSource;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.File;
-import java.io.IOException;
 
 public class ClientCommands implements ClientModInitializer {
 
@@ -59,14 +55,7 @@ public class ClientCommands implements ClientModInitializer {
         CStopSoundCommand.register(dispatcher);
         FovCommand.register(dispatcher);
         HotbarCommand.register(dispatcher);
-        try {
-            KitCommand.loadFile();
-
-            KitCommand.register(dispatcher);
-        } catch (IOException e) {
-            final Logger logger = LogManager.getLogger();
-            logger.error(I18n.translate("commands.ckit.loadFile.failed"));
-        }
+        KitCommand.register(dispatcher);
 
         CrackRNGCommand.register(dispatcher);
 

--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -6,9 +6,13 @@ import net.earthcomputer.clientcommands.script.ScriptManager;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.server.command.ServerCommandSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import java.io.IOException;
 
 public class ClientCommands implements ClientModInitializer {
 
@@ -55,7 +59,14 @@ public class ClientCommands implements ClientModInitializer {
         CStopSoundCommand.register(dispatcher);
         FovCommand.register(dispatcher);
         HotbarCommand.register(dispatcher);
-        KitCommand.register(dispatcher);
+        try {
+            KitCommand.loadFile();
+
+            KitCommand.register(dispatcher);
+        } catch (IOException e) {
+            final Logger logger = LogManager.getLogger();
+            logger.error(I18n.translate("commands.ckit.loadFile.failed"));
+        }
 
         CrackRNGCommand.register(dispatcher);
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/KitCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/KitCommand.java
@@ -12,6 +12,7 @@ import net.fabricmc.fabric.api.util.NbtType;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.command.CommandSource;
 import net.minecraft.datafixer.TypeReferences;
 import net.minecraft.entity.player.PlayerInventory;
@@ -21,6 +22,8 @@ import net.minecraft.screen.slot.Slot;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Util;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,6 +49,15 @@ public class KitCommand {
     private static final MinecraftClient client = MinecraftClient.getInstance();
 
     private static final Map<String, ListTag> kits = new HashMap<>();
+
+    static {
+        try {
+            loadFile();
+        } catch (IOException e) {
+            final Logger logger = LogManager.getLogger();
+            logger.info(I18n.translate("commands.ckit.loadFile.failed"));
+        }
+    }
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         addClientSideCommand("ckit");
@@ -152,11 +164,11 @@ public class KitCommand {
         }
     }
 
-    public static void loadFile() throws IOException {
+    private static void loadFile() throws IOException {
         kits.clear();
         CompoundTag rootTag = NbtIo.read(new File(configPath.toFile(), "kits.dat"));
         if (rootTag == null) {
-            throw new IOException();
+            return;
         }
         final int currentVersion = SharedConstants.getGameVersion().getWorldVersion();
         final int fileVersion = rootTag.getInt("DataVersion");

--- a/src/main/java/net/earthcomputer/clientcommands/command/KitCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/KitCommand.java
@@ -12,7 +12,6 @@ import net.fabricmc.fabric.api.util.NbtType;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.resource.language.I18n;
 import net.minecraft.command.CommandSource;
 import net.minecraft.datafixer.TypeReferences;
 import net.minecraft.entity.player.PlayerInventory;
@@ -37,6 +36,8 @@ import static net.minecraft.server.command.CommandManager.*;
 
 public class KitCommand {
 
+    private static final Logger logger = LogManager.getLogger("clientcommands");
+
     private static final SimpleCommandExceptionType SAVE_FAILED_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("commands.ckit.saveFile.failed"));
 
     private static final DynamicCommandExceptionType ALREADY_EXISTS_EXCEPTION = new DynamicCommandExceptionType(arg -> new TranslatableText("commands.ckit.create.alreadyExists", arg));
@@ -54,8 +55,7 @@ public class KitCommand {
         try {
             loadFile();
         } catch (IOException e) {
-            final Logger logger = LogManager.getLogger();
-            logger.info(I18n.translate("commands.ckit.loadFile.failed"));
+            logger.info("Could not load kits file, hence /ckit will not work!");
         }
     }
 

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -81,7 +81,7 @@
 
   "commands.ckit.notFound": "Kit \"%s\" not found",
   "commands.ckit.saveFile.failed": "Could not save kits file",
-  "commands.ckit.loadFile.failed": "Could not load kits file, hence /ckit is not registered",
+  "commands.ckit.loadFile.failed": "Could not load kits file, hence /ckit will not work!",
   "commands.ckit.load.success": "Successfully gave kit \"%s\" to self",
   "commands.ckit.load.notCreative": "Player must be in creative mode to give items to self",
   "commands.ckit.create.success": "Successfully created kit \"%s\"",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -81,7 +81,6 @@
 
   "commands.ckit.notFound": "Kit \"%s\" not found",
   "commands.ckit.saveFile.failed": "Could not save kits file",
-  "commands.ckit.loadFile.failed": "Could not load kits file, hence /ckit will not work!",
   "commands.ckit.load.success": "Successfully gave kit \"%s\" to self",
   "commands.ckit.load.notCreative": "Player must be in creative mode to give items to self",
   "commands.ckit.create.success": "Successfully created kit \"%s\"",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -81,7 +81,7 @@
 
   "commands.ckit.notFound": "Kit \"%s\" not found",
   "commands.ckit.saveFile.failed": "Could not save kits file",
-  "commands.ckit.loadFile.failed": "Could not load kits file",
+  "commands.ckit.loadFile.failed": "Could not load kits file, hence /ckit is not registered",
   "commands.ckit.load.success": "Successfully gave kit \"%s\" to self",
   "commands.ckit.load.notCreative": "Player must be in creative mode to give items to self",
   "commands.ckit.create.success": "Successfully created kit \"%s\"",


### PR DESCRIPTION
I wanted to do the IO this way earlier, but that wasn't possible as I was storing `PlayerInventory`s which couldn't be loaded without the player. Now that `ListTag`s are stored instead (as suggested by Earthcomputer 👍 ), this **is** possible. The file is only loaded once `onInitializeClient`, and will only be saved afterwards. If the file couldn't be read, the command is logically not registered.