### PR TITLE
Add /ckit preview <name>

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/command/KitCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/KitCommand.java
@@ -22,7 +22,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.*;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.screen.slot.Slot;
-import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;

--- a/src/main/java/net/earthcomputer/clientcommands/command/KitCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/KitCommand.java
@@ -42,7 +42,7 @@ import static net.minecraft.server.command.CommandManager.*;
 
 public class KitCommand {
 
-    private static final Logger logger = LogManager.getLogger("clientcommands");
+    private static final Logger LOGGER = LogManager.getLogger("clientcommands");
 
     private static final SimpleCommandExceptionType SAVE_FAILED_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("commands.ckit.saveFile.failed"));
 
@@ -61,7 +61,7 @@ public class KitCommand {
         try {
             loadFile();
         } catch (IOException e) {
-            logger.info("Could not load kits file, hence /ckit will not work!");
+            LOGGER.info("Could not load kits file, hence /ckit will not work!");
         }
     }
 
@@ -169,6 +169,12 @@ public class KitCommand {
 
         PlayerInventory tempInv = new PlayerInventory(client.player);
         tempInv.deserialize(kit);
+        /*
+            After executing a command, the current screen will be closed (the chat hud).
+            And if you open a new screen in a command, that new screen will be closed
+            instantly along with the chat hud. Slightly delaying the opening of the
+            screen fixes this issue.
+         */
         client.send(() -> client.openScreen(new PreviewScreen(new PlayerScreenHandler(tempInv, true, client.player), tempInv, name)));
         return 0;
     }
@@ -218,17 +224,13 @@ public class KitCommand {
 class PreviewScreen extends AbstractInventoryScreen<PlayerScreenHandler> {
 
     public PreviewScreen(PlayerScreenHandler playerScreenHandler, PlayerInventory inventory, String name) {
-        super(playerScreenHandler, inventory, new LiteralText("kit: " + name).styled(style -> style.withColor(Formatting.RED)));
+        super(playerScreenHandler, inventory, new LiteralText(name).styled(style -> style.withColor(Formatting.RED)));
         this.passEvents = true;
         this.titleX = 80;
     }
 
-    protected void init() {
-        super.init();
-    }
-
     protected void drawForeground(MatrixStack matrices, int mouseX, int mouseY) {
-        this.textRenderer.draw(matrices, this.title, (float) this.titleX, (float) this.titleY, 4210752);
+        this.textRenderer.draw(matrices, this.title, (float) this.titleX, (float) this.titleY, 0x404040);
     }
 
     public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
@@ -243,9 +245,5 @@ class PreviewScreen extends AbstractInventoryScreen<PlayerScreenHandler> {
         RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
         this.client.getTextureManager().bindTexture(BACKGROUND_TEXTURE);
         this.drawTexture(matrices, this.x, this.y, 0, 0, this.backgroundWidth, this.backgroundHeight);
-    }
-
-    public void removed() {
-        super.removed();
     }
 }


### PR DESCRIPTION
Few things. I decided to create my own `PreviewScreen` class, mainly because a `PlayerInventoryScreen` can only be instantiated with a player entity, which is not worth creating. Doing it this way also gets rid of slot interaction code, which might de-sync the client. Even with my own `PreviewScreen` class, you cannot use the player's `PlayerScreenHandler` because that is what actually contains the player's items, where it should contain the kit's items to display. For this reason a `new PlayerScreenHandler()` had to be instatiated. The opening of the screen itself is done using `client.send()`, which _I find_ to be cleaner than doing something like this:
```java
ClientTickEvents.START_CLIENT_TICK.register(client -> {
    if (KitCommand.openScreen != null) {
        client.openScreen(KitCommand.openScreen);
        KitCommand.openScreen = null;
    }
});
```