### PR TITLE
Add the citemgroup command

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -56,6 +56,7 @@ public class ClientCommands implements ClientModInitializer {
         FovCommand.register(dispatcher);
         HotbarCommand.register(dispatcher);
         KitCommand.register(dispatcher);
+        ItemGroupCommand.register(dispatcher);
 
         CrackRNGCommand.register(dispatcher);
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
@@ -20,6 +20,7 @@ import net.minecraft.nbt.*;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.InvalidIdentifierException;
 import net.minecraft.util.Util;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,6 +46,7 @@ public class ItemGroupCommand {
     private static final DynamicCommandExceptionType OUT_OF_BOUNDS_EXCEPTION = new DynamicCommandExceptionType(arg -> new TranslatableText("commands.citemgroup.outOfBounds", arg));
 
     private static final SimpleCommandExceptionType SAVE_FAILED_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("commands.citemgroup.saveFile.failed"));
+    private static final DynamicCommandExceptionType ILLEGAL_CHARACTER_EXCEPTION = new DynamicCommandExceptionType(arg -> new TranslatableText("commands.citemgroup.addGroup.illegalCharacter", arg));
     private static final DynamicCommandExceptionType ALREADY_EXISTS_EXCEPTION = new DynamicCommandExceptionType(arg -> new TranslatableText("commands.citemgroup.addGroup.alreadyExists", arg));
 
     private static final Path configPath = FabricLoader.getInstance().getConfigDir().resolve("clientcommands");
@@ -98,14 +100,18 @@ public class ItemGroupCommand {
             throw ALREADY_EXISTS_EXCEPTION.create(name);
         }
 
-        ItemGroup itemGroup = FabricItemGroupBuilder.create(
-                new Identifier("clientcommands", name))
-                .icon(() -> icon)
-                .build();
+        try {
+            ItemGroup itemGroup = FabricItemGroupBuilder.create(
+                    new Identifier("clientcommands", name))
+                    .icon(() -> icon)
+                    .build();
 
-        groups.put(name, new Group(itemGroup, icon, new ListTag()));
-        saveFile();
-        sendFeedback("commands.citemgroup.addGroup.success", name);
+            groups.put(name, new Group(itemGroup, icon, new ListTag()));
+            saveFile();
+            sendFeedback("commands.citemgroup.addGroup.success", name);
+        } catch (InvalidIdentifierException e) {
+            throw ILLEGAL_CHARACTER_EXCEPTION.create(name);
+        }
         return 0;
     }
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
@@ -27,21 +27,15 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.HashMap;
+import java.util.Map;
 
-import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
-import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
-import static com.mojang.brigadier.arguments.StringArgumentType.getString;
-import static com.mojang.brigadier.arguments.StringArgumentType.string;
-import static net.earthcomputer.clientcommands.command.ClientCommandManager.addClientSideCommand;
-import static net.earthcomputer.clientcommands.command.ClientCommandManager.sendFeedback;
-import static net.minecraft.command.CommandSource.suggestMatching;
-import static net.minecraft.command.argument.ItemStackArgumentType.getItemStackArgument;
-import static net.minecraft.command.argument.ItemStackArgumentType.itemStack;
-import static net.minecraft.server.command.CommandManager.argument;
-import static net.minecraft.server.command.CommandManager.literal;
-
+import static com.mojang.brigadier.arguments.IntegerArgumentType.*;
+import static com.mojang.brigadier.arguments.StringArgumentType.*;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
+import static net.minecraft.command.CommandSource.*;
+import static net.minecraft.command.argument.ItemStackArgumentType.*;
+import static net.minecraft.server.command.CommandManager.*;
 
 public class ItemGroupCommand {
 
@@ -57,7 +51,7 @@ public class ItemGroupCommand {
 
     private static final MinecraftClient client = MinecraftClient.getInstance();
 
-    private static final SortedMap<String, Group> groups = new TreeMap<>();
+    private static final Map<String, Group> groups = new HashMap<>();
 
     static {
         try {

--- a/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
@@ -106,18 +106,17 @@ public class ItemGroupCommand {
             throw ALREADY_EXISTS_EXCEPTION.create(name);
         }
 
-        try {
-            ItemGroup itemGroup = FabricItemGroupBuilder.create(
-                    new Identifier("clientcommands", name))
-                    .icon(() -> icon)
-                    .build();
-
-            groups.put(name, new Group(itemGroup, icon, new ListTag()));
-            saveFile();
-            sendFeedback("commands.citemgroup.addGroup.success", name);
-        } catch (InvalidIdentifierException e) {
+        final Identifier identifier = Identifier.tryParse("clientcommands:" + name);
+        if (identifier == null) {
             throw ILLEGAL_CHARACTER_EXCEPTION.create(name);
         }
+        ItemGroup itemGroup = FabricItemGroupBuilder.create(identifier)
+                .icon(() -> icon)
+                .build();
+
+        groups.put(name, new Group(itemGroup, icon, new ListTag()));
+        saveFile();
+        sendFeedback("commands.citemgroup.addGroup.success", name);
         return 0;
     }
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
@@ -59,7 +59,7 @@ public class ItemGroupCommand {
         try {
             loadFile();
         } catch (IOException e) {
-            LOGGER.info("Could not load groups file, hence /citemgroup will not work!");
+            LOGGER.error("Could not load groups file, hence /citemgroup will not work!", e);
         }
     }
 
@@ -68,31 +68,31 @@ public class ItemGroupCommand {
 
         LiteralCommandNode<ServerCommandSource> citemgroup = dispatcher.register(literal("citemgroup"));
         dispatcher.register(literal("citemgroup")
-                .then(literal("modify")
-                        .then(argument("group", string())
-                                .suggests((ctx, builder) -> suggestMatching(groups.keySet(), builder))
-                                .then(literal("add")
-                                        .then(argument("itemstack", itemStack())
-                                                .then(argument("count", integer(1))
-                                                        .executes(ctx -> addStack(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "itemstack").createStack(getInteger(ctx, "count"), false))))
-                                                .executes(ctx -> addStack(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "itemstack").createStack(1, false)))))
-                                .then(literal("remove")
-                                        .then(argument("index", integer(0))
-                                                .executes(ctx -> removeStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index")))))
-                                .then(literal("set")
-                                        .then(argument("index", integer(0))
-                                                .then(argument("itemstack", itemStack())
-                                                        .then(argument("count", integer(1))
-                                                                .executes(ctx -> setStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index"), getItemStackArgument(ctx, "itemstack").createStack(getInteger(ctx, "count"), false))))
-                                                        .executes(ctx -> setStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index"), getItemStackArgument(ctx, "itemstack").createStack(1, false))))))))
-                .then(literal("add")
-                        .then(argument("group", string())
-                                .then(argument("icon", itemStack())
-                                        .executes(ctx -> addGroup(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "icon").createStack(1, false))))))
-                .then(literal("remove")
-                        .then(argument("group", string())
-                                .suggests((ctx, builder) -> suggestMatching(groups.keySet(), builder))
-                                .executes(ctx -> removeGroup(ctx.getSource(), getString(ctx, "group"))))));
+            .then(literal("modify")
+                .then(argument("group", string())
+                    .suggests((ctx, builder) -> suggestMatching(groups.keySet(), builder))
+                    .then(literal("add")
+                        .then(argument("itemstack", itemStack())
+                            .then(argument("count", integer(1))
+                                .executes(ctx -> addStack(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "itemstack").createStack(getInteger(ctx, "count"), false))))
+                            .executes(ctx -> addStack(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "itemstack").createStack(1, false)))))
+                    .then(literal("remove")
+                        .then(argument("index", integer(0))
+                            .executes(ctx -> removeStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index")))))
+                    .then(literal("set")
+                        .then(argument("index", integer(0))
+                            .then(argument("itemstack", itemStack())
+                                .then(argument("count", integer(1))
+                                    .executes(ctx -> setStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index"), getItemStackArgument(ctx, "itemstack").createStack(getInteger(ctx, "count"), false))))
+                                .executes(ctx -> setStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index"), getItemStackArgument(ctx, "itemstack").createStack(1, false))))))))
+            .then(literal("add")
+                .then(argument("group", string())
+                    .then(argument("icon", itemStack())
+                         .executes(ctx -> addGroup(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "icon").createStack(1, false))))))
+            .then(literal("remove")
+                .then(argument("group", string())
+                    .suggests((ctx, builder) -> suggestMatching(groups.keySet(), builder))
+                    .executes(ctx -> removeGroup(ctx.getSource(), getString(ctx, "group"))))));
     }
 
     private static int addGroup(ServerCommandSource source, String name, ItemStack icon) throws CommandSyntaxException {

--- a/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/ItemGroupCommand.java
@@ -1,0 +1,307 @@
+package net.earthcomputer.clientcommands.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.mojang.serialization.Dynamic;
+import net.earthcomputer.clientcommands.interfaces.IItemGroup;
+import net.earthcomputer.clientcommands.mixin.CreativeInventoryScreenAccessor;
+import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
+import net.fabricmc.fabric.api.util.NbtType;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.SharedConstants;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.datafixer.TypeReferences;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.*;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
+import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
+import static com.mojang.brigadier.arguments.StringArgumentType.getString;
+import static com.mojang.brigadier.arguments.StringArgumentType.string;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.addClientSideCommand;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.sendFeedback;
+import static net.minecraft.command.CommandSource.suggestMatching;
+import static net.minecraft.command.argument.ItemStackArgumentType.getItemStackArgument;
+import static net.minecraft.command.argument.ItemStackArgumentType.itemStack;
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+
+public class ItemGroupCommand {
+
+    private static final Logger LOGGER = LogManager.getLogger("clientcommands");
+
+    private static final DynamicCommandExceptionType NOT_FOUND_EXCEPTION = new DynamicCommandExceptionType(arg -> new TranslatableText("commands.citemgroup.notFound", arg));
+    private static final DynamicCommandExceptionType OUT_OF_BOUNDS_EXCEPTION = new DynamicCommandExceptionType(arg -> new TranslatableText("commands.citemgroup.outOfBounds", arg));
+
+    private static final SimpleCommandExceptionType SAVE_FAILED_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("commands.citemgroup.saveFile.failed"));
+    private static final DynamicCommandExceptionType ALREADY_EXISTS_EXCEPTION = new DynamicCommandExceptionType(arg -> new TranslatableText("commands.citemgroup.addGroup.alreadyExists", arg));
+
+    private static final Path configPath = FabricLoader.getInstance().getConfigDir().resolve("clientcommands");
+
+    private static final MinecraftClient client = MinecraftClient.getInstance();
+
+    private static final SortedMap<String, Group> groups = new TreeMap<>();
+
+    static {
+        try {
+            loadFile();
+        } catch (IOException e) {
+            LOGGER.info("Could not load groups file, hence /citemgroup will not work!");
+        }
+    }
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        addClientSideCommand("citemgroup");
+
+        LiteralCommandNode<ServerCommandSource> citemgroup = dispatcher.register(literal("citemgroup"));
+        dispatcher.register(literal("citemgroup")
+                .then(literal("modify")
+                        .then(argument("group", string())
+                                .suggests((ctx, builder) -> suggestMatching(groups.keySet(), builder))
+                                .then(literal("add")
+                                        .then(argument("itemstack", itemStack())
+                                                .then(argument("count", integer(1))
+                                                        .executes(ctx -> addStack(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "itemstack").createStack(getInteger(ctx, "count"), false))))
+                                                .executes(ctx -> addStack(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "itemstack").createStack(1, false)))))
+                                .then(literal("remove")
+                                        .then(argument("index", integer(0))
+                                                .executes(ctx -> removeStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index")))))
+                                .then(literal("set")
+                                        .then(argument("index", integer(0))
+                                                .then(argument("itemstack", itemStack())
+                                                        .then(argument("count", integer(1))
+                                                                .executes(ctx -> setStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index"), getItemStackArgument(ctx, "itemstack").createStack(getInteger(ctx, "count"), false))))
+                                                        .executes(ctx -> setStack(ctx.getSource(), getString(ctx, "group"), getInteger(ctx, "index"), getItemStackArgument(ctx, "itemstack").createStack(1, false))))))))
+                .then(literal("add")
+                        .then(argument("group", string())
+                                .then(argument("icon", itemStack())
+                                        .executes(ctx -> addGroup(ctx.getSource(), getString(ctx, "group"), getItemStackArgument(ctx, "icon").createStack(1, false))))))
+                .then(literal("remove")
+                        .then(argument("group", string())
+                                .suggests((ctx, builder) -> suggestMatching(groups.keySet(), builder))
+                                .executes(ctx -> removeGroup(ctx.getSource(), getString(ctx, "group"))))));
+    }
+
+    private static int addGroup(ServerCommandSource source, String name, ItemStack icon) throws CommandSyntaxException {
+        if (groups.containsKey(name)) {
+            throw ALREADY_EXISTS_EXCEPTION.create(name);
+        }
+
+        ItemGroup itemGroup = FabricItemGroupBuilder.create(
+                new Identifier("clientcommands", name))
+                .icon(() -> icon)
+                .build();
+
+        groups.put(name, new Group(itemGroup, icon, new ListTag()));
+        saveFile();
+        sendFeedback("commands.citemgroup.addGroup.success", name);
+        return 0;
+    }
+
+    private static int removeGroup(ServerCommandSource source, String name) throws CommandSyntaxException {
+        if (!groups.containsKey(name)) {
+            throw NOT_FOUND_EXCEPTION.create(name);
+        }
+
+        groups.remove(name);
+
+        reloadGroups(12);
+        CreativeInventoryScreenAccessor.setSelectedTab(0);
+        CreativeInventoryScreenAccessor.setFabricCurrentPage(0);
+        saveFile();
+        sendFeedback("commands.citemgroup.removeGroup.success", name);
+        return 0;
+    }
+
+    private static int addStack(ServerCommandSource source, String name, ItemStack itemStack) throws CommandSyntaxException {
+        if (!groups.containsKey(name)) {
+            throw NOT_FOUND_EXCEPTION.create(name);
+        }
+
+        Group group = groups.get(name);
+        ListTag items = group.getItems();
+        ItemGroup itemGroup = group.getItemGroup();
+        items.add(itemStack.toTag(new CompoundTag()));
+
+        reloadGroups(itemGroup.getIndex());
+        saveFile();
+        sendFeedback("commands.citemgroup.addStack.success", itemStack.getItem().getName().getString(), name);
+        return 0;
+    }
+
+    private static int removeStack(ServerCommandSource source, String name, int index) throws CommandSyntaxException {
+        if (!groups.containsKey(name)) {
+            throw NOT_FOUND_EXCEPTION.create(name);
+        }
+
+        Group group = groups.get(name);
+        ListTag items = group.getItems();
+        if (index < 0 || index > items.size()) {
+            throw OUT_OF_BOUNDS_EXCEPTION.create(index);
+        }
+        ItemGroup itemGroup = group.getItemGroup();
+        items.remove(index);
+
+        reloadGroups(itemGroup.getIndex());
+        saveFile();
+        sendFeedback("commands.citemgroup.removeStack.success", name, index);
+        return 0;
+    }
+
+    private static int setStack(ServerCommandSource source, String name, int index, ItemStack itemStack) throws CommandSyntaxException {
+        if (!groups.containsKey(name)) {
+            throw NOT_FOUND_EXCEPTION.create(name);
+        }
+
+        Group group = groups.get(name);
+        ListTag items = group.getItems();
+        if ((index < 0) || (index > items.size())) {
+            throw OUT_OF_BOUNDS_EXCEPTION.create(index);
+        }
+        ItemGroup itemGroup = group.getItemGroup();
+        items.set(index, itemStack.toTag(new CompoundTag()));
+
+        reloadGroups(itemGroup.getIndex());
+        saveFile();
+        sendFeedback("commands.citemgroup.setStack.success", name, index, itemStack.getItem().getName().getString());
+        return 0;
+    }
+
+    private static void saveFile() throws CommandSyntaxException {
+        try {
+            CompoundTag rootTag = new CompoundTag();
+            CompoundTag compoundTag = new CompoundTag();
+            groups.forEach((key, value) -> {
+                CompoundTag group = new CompoundTag();
+                group.put("icon", value.getIcon().toTag(new CompoundTag()));
+                group.put("items", value.getItems());
+                compoundTag.put(key, group);
+            });
+            rootTag.putInt("DataVersion", SharedConstants.getGameVersion().getWorldVersion());
+            rootTag.put("Groups", compoundTag);
+            File newFile = File.createTempFile("groups", ".dat", configPath.toFile());
+            NbtIo.write(rootTag, newFile);
+            File backupFile = new File(configPath.toFile(), "groups.dat_old");
+            File currentFile = new File(configPath.toFile(), "groups.dat");
+            Util.backupAndReplace(currentFile, newFile, backupFile);
+        } catch (IOException e) {
+            throw SAVE_FAILED_EXCEPTION.create();
+        }
+    }
+
+    private static void loadFile() throws IOException {
+        groups.clear();
+        CompoundTag rootTag = NbtIo.read(new File(configPath.toFile(), "groups.dat"));
+        if (rootTag == null) {
+            return;
+        }
+        final int currentVersion = SharedConstants.getGameVersion().getWorldVersion();
+        final int fileVersion = rootTag.getInt("DataVersion");
+        CompoundTag compoundTag = rootTag.getCompound("Groups");
+        if (fileVersion >= currentVersion) {
+            compoundTag.getKeys().forEach(key -> {
+                CompoundTag group = compoundTag.getCompound(key);
+                ItemStack icon = ItemStack.fromTag(group.getCompound("icon"));
+                ListTag items = group.getList("items", NbtType.COMPOUND);
+                ItemGroup itemGroup = FabricItemGroupBuilder.create(
+                        new Identifier("clientcommands", key))
+                        .icon(() -> icon)
+                        .appendItems(stacks -> {
+                            for (int i = 0; i < items.size(); i++) {
+                                stacks.add(ItemStack.fromTag(items.getCompound(i)));
+                            }
+                        })
+                        .build();
+                groups.put(key, new Group(itemGroup, icon, items));
+            });
+        } else {
+            compoundTag.getKeys().forEach(key -> {
+                CompoundTag group = compoundTag.getCompound(key);
+                Dynamic<Tag> oldStackDynamic = new Dynamic<>(NbtOps.INSTANCE, group.getCompound("icon"));
+                Dynamic<Tag> newStackDynamic = client.getDataFixer().update(TypeReferences.ITEM_STACK, oldStackDynamic, fileVersion, currentVersion);
+                ItemStack icon = ItemStack.fromTag((CompoundTag) newStackDynamic.getValue());
+
+                ListTag updatedListTag = new ListTag();
+                group.getList("items", NbtType.COMPOUND).forEach(tag -> {
+                    Dynamic<Tag> oldTagDynamic = new Dynamic<>(NbtOps.INSTANCE, tag);
+                    Dynamic<Tag> newTagDynamic = client.getDataFixer().update(TypeReferences.ITEM_STACK, oldTagDynamic, fileVersion, currentVersion);
+                    updatedListTag.add(newTagDynamic.getValue());
+                });
+                ItemGroup itemGroup = FabricItemGroupBuilder.create(
+                        new Identifier("clientcommands", key))
+                        .icon(() -> icon)
+                        .appendItems(stacks -> {
+                            for (int i = 0; i < updatedListTag.size(); i++) {
+                                stacks.add(ItemStack.fromTag(updatedListTag.getCompound(i)));
+                            }
+                        })
+                        .build();
+                groups.put(key, new Group(itemGroup, icon, updatedListTag));
+            });
+        }
+    }
+
+    private static void reloadGroups(int groupIndex) {
+        ((IItemGroup) ItemGroup.BUILDING_BLOCKS).shrink(groupIndex);
+
+        for (String key : groups.keySet()) {
+            if (groups.get(key).getItemGroup().getIndex() >= groupIndex) {
+                groups.get(key).setItemGroup(FabricItemGroupBuilder.create(
+                        new Identifier("clientcommands", key))
+                        .icon(() -> groups.get(key).getIcon())
+                        .appendItems(stacks -> {
+                            for (int i = 0; i < groups.get(key).getItems().size(); i++) {
+                                stacks.add(ItemStack.fromTag(groups.get(key).getItems().getCompound(i)));
+                            }
+                        })
+                        .build());
+            }
+        }
+    }
+}
+
+class Group {
+
+    private ItemGroup itemGroup;
+    private final ItemStack icon;
+    private final ListTag items;
+
+    public Group(ItemGroup itemGroup, ItemStack icon, ListTag items) {
+        this.itemGroup = itemGroup;
+        this.icon = icon;
+        this.items = items;
+    }
+
+    public ItemGroup getItemGroup() {
+        return this.itemGroup;
+    }
+
+    public ItemStack getIcon() {
+        return this.icon;
+    }
+
+    public ListTag getItems() {
+        return this.items;
+    }
+
+    public void setItemGroup(ItemGroup itemGroup) {
+        this.itemGroup = itemGroup;
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/interfaces/IItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/interfaces/IItemGroup.java
@@ -1,7 +1,5 @@
 package net.earthcomputer.clientcommands.interfaces;
 
 public interface IItemGroup {
-    int getLength();
-
     void shrink();
 }

--- a/src/main/java/net/earthcomputer/clientcommands/interfaces/IItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/interfaces/IItemGroup.java
@@ -1,0 +1,7 @@
+package net.earthcomputer.clientcommands.interfaces;
+
+public interface IItemGroup {
+    int getLength();
+
+    void shrink(int index);
+}

--- a/src/main/java/net/earthcomputer/clientcommands/interfaces/IItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/interfaces/IItemGroup.java
@@ -3,5 +3,5 @@ package net.earthcomputer.clientcommands.interfaces;
 public interface IItemGroup {
     int getLength();
 
-    void shrink(int index);
+    void shrink();
 }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/CreativeInventoryScreenAccessor.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/CreativeInventoryScreenAccessor.java
@@ -1,5 +1,6 @@
 package net.earthcomputer.clientcommands.mixin;
 
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -12,7 +13,7 @@ public interface CreativeInventoryScreenAccessor {
     }
 
     @SuppressWarnings("AccessorTarget")
-    @Accessor(value = "fabric_currentPage", remap = false)
+    @Dynamic @Accessor(value = "fabric_currentPage", remap = false)
     static void setFabricCurrentPage(int index) {
         throw new AssertionError();
     }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/CreativeInventoryScreenAccessor.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/CreativeInventoryScreenAccessor.java
@@ -1,0 +1,19 @@
+package net.earthcomputer.clientcommands.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(targets = "net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen")
+public interface CreativeInventoryScreenAccessor {
+
+    @Accessor("selectedTab")
+    static void setSelectedTab(int selectedTab) {
+        throw new AssertionError();
+    }
+
+    @SuppressWarnings("AccessorTarget")
+    @Accessor(value = "fabric_currentPage", remap = false)
+    static void setFabricCurrentPage(int index) {
+        throw new AssertionError();
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
@@ -23,15 +23,7 @@ public abstract class MixinItemGroup implements IItemGroup {
 
     @Override
     public void shrink() {
-        ItemGroup[] tempGroups = GROUPS;
-        tempGroups = Arrays.stream(tempGroups).filter(itemGroup -> !itemGroup.getName().startsWith("clientcommands.")).toArray(ItemGroup[]::new);
-        GROUPS = new ItemGroup[tempGroups.length];
-        System.arraycopy(tempGroups, 0, GROUPS, 0, GROUPS.length);
-    }
-
-    @Override
-    public int getLength() {
-        return GROUPS.length;
+        GROUPS = Arrays.stream(GROUPS).filter(itemGroup -> !itemGroup.getName().startsWith("clientcommands.")).toArray(ItemGroup[]::new);
     }
 
     @Inject(method = "<init>", at = @At("TAIL"))

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
@@ -15,9 +15,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ItemGroup.class)
 public abstract class MixinItemGroup implements IItemGroup {
 
-    @Shadow @Final @Mutable public static ItemGroup[] GROUPS;
+    @Shadow @Mutable @Final public static ItemGroup[] GROUPS;
 
-    @Mutable @Shadow @Final private Text translationKey;
+    @Shadow @Mutable @Final private Text translationKey;
 
     @Override
     public void shrink(int index) {

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
@@ -12,6 +12,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Arrays;
+
 @Mixin(ItemGroup.class)
 public abstract class MixinItemGroup implements IItemGroup {
 
@@ -20,9 +22,10 @@ public abstract class MixinItemGroup implements IItemGroup {
     @Shadow @Mutable @Final private Text translationKey;
 
     @Override
-    public void shrink(int index) {
+    public void shrink() {
         ItemGroup[] tempGroups = GROUPS;
-        GROUPS = new ItemGroup[index];
+        tempGroups = Arrays.stream(tempGroups).filter(itemGroup -> !itemGroup.getName().startsWith("clientcommands.")).toArray(ItemGroup[]::new);
+        GROUPS = new ItemGroup[tempGroups.length];
         System.arraycopy(tempGroups, 0, GROUPS, 0, GROUPS.length);
     }
 

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
@@ -2,15 +2,22 @@ package net.earthcomputer.clientcommands.mixin;
 
 import net.earthcomputer.clientcommands.interfaces.IItemGroup;
 import net.minecraft.item.ItemGroup;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ItemGroup.class)
 public abstract class MixinItemGroup implements IItemGroup {
 
     @Shadow @Final @Mutable public static ItemGroup[] GROUPS;
+
+    @Mutable @Shadow @Final private Text translationKey;
 
     @Override
     public void shrink(int index) {
@@ -22,5 +29,12 @@ public abstract class MixinItemGroup implements IItemGroup {
     @Override
     public int getLength() {
         return GROUPS.length;
+    }
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void substring(int index, String id, CallbackInfo ci) {
+        if (id.contains("clientcommands.")) {
+            this.translationKey = new LiteralText(id.substring(15));
+        }
     }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
@@ -33,7 +33,7 @@ public abstract class MixinItemGroup implements IItemGroup {
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void substring(int index, String id, CallbackInfo ci) {
-        if (id.contains("clientcommands.")) {
+        if (id.startsWith("clientcommands.")) {
             this.translationKey = new LiteralText(id.substring(15));
         }
     }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinItemGroup.java
@@ -1,0 +1,26 @@
+package net.earthcomputer.clientcommands.mixin;
+
+import net.earthcomputer.clientcommands.interfaces.IItemGroup;
+import net.minecraft.item.ItemGroup;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ItemGroup.class)
+public abstract class MixinItemGroup implements IItemGroup {
+
+    @Shadow @Final @Mutable public static ItemGroup[] GROUPS;
+
+    @Override
+    public void shrink(int index) {
+        ItemGroup[] tempGroups = GROUPS;
+        GROUPS = new ItemGroup[index];
+        System.arraycopy(tempGroups, 0, GROUPS, 0, GROUPS.length);
+    }
+
+    @Override
+    public int getLength() {
+        return GROUPS.length;
+    }
+}

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -79,6 +79,16 @@
   "commands.chotbar.notCreative": "Player must be in creative mode to restore item hotbars",
   "commands.chotbar.restoredHotbar": "Restored item hotbar %d",
 
+  "commands.citemgroup.notFound": "Item group \"%s\" not found",
+  "commands.citemgroup.outOfBounds": "Index %d is out of bounds",
+  "commands.citemgroup.saveFile.failed": "Could not save item groups file",
+  "commands.citemgroup.addGroup.success": "Successfully added item group \"%s\"",
+  "commands.citemgroup.addGroup.alreadyExists": "Item group \"%s\" already exists",
+  "commands.citemgroup.removeGroup.success": "Successfully removed item group \"%s\"",
+  "commands.citemgroup.addStack.success": "Successfully added %s to \"%s\"",
+  "commands.citemgroup.removeStack.success": "Successfully removed stack from \"%s\" at index %d",
+  "commands.citemgroup.setStack.success": "Successfully set the stack from \"%s\" at index %d to %s",
+
   "commands.ckit.notFound": "Kit \"%s\" not found",
   "commands.ckit.saveFile.failed": "Could not save kits file",
   "commands.ckit.load.success": "Successfully gave kit \"%s\" to self",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -83,6 +83,7 @@
   "commands.citemgroup.outOfBounds": "Index %d is out of bounds",
   "commands.citemgroup.saveFile.failed": "Could not save item groups file",
   "commands.citemgroup.addGroup.success": "Successfully added item group \"%s\"",
+  "commands.citemgroup.addGroup.illegalCharacter": "Item groups can only contain [a-z0-9/._-] characters",
   "commands.citemgroup.addGroup.alreadyExists": "Item group \"%s\" already exists",
   "commands.citemgroup.removeGroup.success": "Successfully removed item group \"%s\"",
   "commands.citemgroup.addStack.success": "Successfully added %s to \"%s\"",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -89,6 +89,8 @@
   "commands.citemgroup.addStack.success": "Successfully added %s to \"%s\"",
   "commands.citemgroup.removeStack.success": "Successfully removed stack from \"%s\" at index %d",
   "commands.citemgroup.setStack.success": "Successfully set the stack from \"%s\" at index %d to %s",
+  "commands.citemgroup.changeIcon.success": "Successfully changed the icon of \"%s\" from %s to %s",
+  "commands.citemgroup.renameGroup.success": "Successfully renamed item group \"%s\" to \"%s\"",
 
   "commands.ckit.notFound": "Kit \"%s\" not found",
   "commands.ckit.saveFile.failed": "Could not save kits file",

--- a/src/main/resources/mixins.clientcommands.json
+++ b/src/main/resources/mixins.clientcommands.json
@@ -68,7 +68,9 @@
     "MixinStonecutterContainer",
     "MixinTextFieldWidget",
     "ProjectileEntityAccessor",
-    "ScreenHandlerAccessor"
+    "ScreenHandlerAccessor",
+    "MixinItemGroup",
+    "CreativeInventoryScreenAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Closes #235 

This. Was. A. Lot. Of. Pain.

This took me absolutely ages to code, but I'm finally done. Dynamically changing item groups is HARD. I initally got this working with `ItemGroup#appendStacks()`, but that turned out to be abuse of the method. After that was no longer an option, I tried setting the `group` for an `Item`, which removed the item from the vanilla groups 🤣. The last option was to recreate the entire item group to "modify" it. While this may sound inefficient, I did manage to optimise it by only recreating the item groups >= the to be modified group.