### PR TITLE
chelp paging implementation

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/Page.java
+++ b/src/main/java/net/earthcomputer/clientcommands/Page.java
@@ -2,14 +2,12 @@ package net.earthcomputer.clientcommands;
 
 import java.util.List;
 
-public class Page<T>
-{
-    public final List<T> Items;
-    public final int PageNumber;
+public class Page<T> {
+    public final List<T> items;
+    public final int pageNumber;
 
-    public Page(List<T> arr, int pageNumber)
-    {
-        Items = arr;
-        PageNumber = pageNumber;
+    public Page(List<T> arr, int pageNumber) {
+        this.items = arr;
+        this.pageNumber = pageNumber;
     }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/Page.java
+++ b/src/main/java/net/earthcomputer/clientcommands/Page.java
@@ -1,0 +1,15 @@
+package net.earthcomputer.clientcommands;
+
+import java.util.List;
+
+public class Page<T>
+{
+    public final List<T> Items;
+    public final int PageNumber;
+
+    public Page(List<T> arr, int pageNumber)
+    {
+        Items = arr;
+        PageNumber = pageNumber;
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/Paginator.java
+++ b/src/main/java/net/earthcomputer/clientcommands/Paginator.java
@@ -2,55 +2,46 @@ package net.earthcomputer.clientcommands;
 
 import java.util.List;
 
-public class Paginator<T>
-{
+public class Paginator<T> {
 
-    private final List<T> _list;
-    public final int Pagesize;
+    private final List<T> list;
+    public final int pageSize;
 
-    public Paginator(List<T> list, int pagesize)
-    {
-        _list = list;
-        Pagesize = pagesize;
+    public Paginator(List<T> list, int pageSize) {
+        this.list = list;
+        this.pageSize = pageSize;
     }
 
-    public Page<T> getPage(int pageNumber)
-    {
+    public Page<T> getPage(int pageNumber) {
 
-        if(!isValidPage(pageNumber))
-        {
+        if(!isValidPage(pageNumber)) {
             throw new IndexOutOfBoundsException("Page number must start from 1 to 'N' Pages");
         }
 
         int index = pageNumber - 1;
-        int pageStart = index * Pagesize;
+        int pageStart = index * this.pageSize;
         int indexofEnd = 0;
 
-        if(pageStart + Pagesize <= getItemsTotal())
-        {
-            indexofEnd = pageStart + Pagesize;
+        if(pageStart + this.pageSize <= getItemsTotal()) {
+            indexofEnd = pageStart + this.pageSize;
         }
-        else
-        {
+        else {
             indexofEnd = getItemsTotal();
         }
 
-        return new Page<T>(_list.subList(pageStart, indexofEnd), pageNumber);
+        return new Page<T>(this.list.subList(pageStart, indexofEnd), pageNumber);
     }
 
-    public boolean isValidPage(int pageNumber)
-    {
+    public boolean isValidPage(int pageNumber) {
         return !(pageNumber > getPageCount() || pageNumber < 1);
     }
 
-    public int getItemsTotal()
-    {
-        return _list.size();
+    public int getItemsTotal() {
+        return this.list.size();
     }
 
-    public int getPageCount()
-    {
-        return (int) Math.ceil((float) getItemsTotal() / (float) Pagesize);
+    public int getPageCount() {
+        return (int) Math.ceil((float) getItemsTotal() / (float) pageSize);
     }
 
 

--- a/src/main/java/net/earthcomputer/clientcommands/Paginator.java
+++ b/src/main/java/net/earthcomputer/clientcommands/Paginator.java
@@ -1,0 +1,59 @@
+package net.earthcomputer.clientcommands;
+
+import java.util.List;
+
+public class Paginator<T>
+{
+
+    private final List<T> _list;
+    public final int Pagesize;
+
+    public Paginator(List<T> list, int pagesize)
+    {
+        _list = list;
+        Pagesize = pagesize;
+    }
+
+    public Page<T> getPage(int pageNumber)
+    {
+
+        if(!isValidPage(pageNumber))
+        {
+            throw new IndexOutOfBoundsException("Page number must start from 1 to 'N' Pages");
+        }
+
+        int index = pageNumber - 1;
+        int pageStart = index * Pagesize;
+        int indexofEnd = 0;
+
+        if(pageStart + Pagesize <= getItemsTotal())
+        {
+            indexofEnd = pageStart + Pagesize;
+        }
+        else
+        {
+            indexofEnd = getItemsTotal();
+        }
+
+        return new Page<T>(_list.subList(pageStart, indexofEnd), pageNumber);
+    }
+
+    public boolean isValidPage(int pageNumber)
+    {
+        return !(pageNumber > getPageCount() || pageNumber < 1);
+    }
+
+    public int getItemsTotal()
+    {
+        return _list.size();
+    }
+
+    public int getPageCount()
+    {
+        return (int) Math.ceil((float) getItemsTotal() / (float) Pagesize);
+    }
+
+
+
+}
+

--- a/src/main/java/net/earthcomputer/clientcommands/command/CHelpCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CHelpCommand.java
@@ -31,27 +31,28 @@ public class CHelpCommand {
                 int cmdCount = 0;
 
                 List<String> commandNames = new ArrayList<String>();
-                for(CommandNode<ServerCommandSource> command : dispatcher.getRoot().getChildren())
-                {
+                for(CommandNode<ServerCommandSource> command : dispatcher.getRoot().getChildren()) {
+
                     String commandName = command.getName();
-                    if(isClientSideCommand(commandName))
-                    {
+
+                    if(isClientSideCommand(commandName)) {
                         commandNames.add('/' + commandName);
                         cmdCount++;
                     }
+
                 }
 
                 Paginator<String> paginator = new Paginator<String>(commandNames, 19);
                 Page<String> page = paginator.getPage(1);
-                for (int i = 0; i < page.Items.size(); i++)
-                {
-                    sendFeedback(page.Items.get(i));
+
+                for (int i = 0; i < page.items.size(); i++) {
+                    sendFeedback(page.items.get(i));
                 }
 
                 sendFeedback(new LiteralText("")
-                        .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.left"), String.format("/chelp %d", page.PageNumber - 1)))
-                        .append(new TranslatableText("commands.chelp.paging.body", page.PageNumber, paginator.getPageCount()))
-                        .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.right"), String.format("/chelp %d", page.PageNumber + 1))));
+                        .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.left"), String.format("/chelp %d", page.pageNumber - 1)))
+                        .append(new TranslatableText("commands.chelp.paging.body", page.pageNumber, paginator.getPageCount()))
+                        .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.right"), String.format("/chelp %d", page.pageNumber + 1))));
 
                 return cmdCount;
 
@@ -61,37 +62,38 @@ public class CHelpCommand {
 
                     String userInput = getString(ctx, "page | command");
 
-                    if(isInteger(userInput))
-                    {
-                        int userPage = Integer.parseInt(userInput);
+                    if(isInteger(userInput)) {
 
+                        int userPage = Integer.parseInt(userInput);
                         List<String> commandNames = new ArrayList<String>();
-                        for(CommandNode<ServerCommandSource> command : dispatcher.getRoot().getChildren())
-                        {
+
+                        for(CommandNode<ServerCommandSource> command : dispatcher.getRoot().getChildren()) {
                             String commandName = command.getName();
-                            if(isClientSideCommand(commandName))
-                            {
+
+                            if(isClientSideCommand(commandName)) {
                                 commandNames.add('/' + commandName);
                             }
                         }
+
                         Paginator<String> paginator = new Paginator<String>(commandNames, 19);
-                        if(!paginator.isValidPage(userPage))
-                        {
+
+                        if(!paginator.isValidPage(userPage)) {
                             sendFeedback(new TranslatableText("commands.chelp.paging.incorrect", userPage));
                             return 0;
                         }
+
                         Page<String> page = paginator.getPage(userPage);
-                        for (int i = 0; i < page.Items.size(); i++)
-                        {
-                            sendFeedback(page.Items.get(i));
+
+                        for (int i = 0; i < page.items.size(); i++) {
+                            sendFeedback(page.items.get(i));
                         }
 
                         sendFeedback(new LiteralText("")
-                                .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.left"), String.format("/chelp %d", page.PageNumber - 1)))
-                                .append(new TranslatableText("commands.chelp.paging.body", page.PageNumber, paginator.getPageCount()))
-                                .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.right"), String.format("/chelp %d", page.PageNumber + 1))));
+                                .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.left"), String.format("/chelp %d", page.pageNumber - 1)))
+                                .append(new TranslatableText("commands.chelp.paging.body", page.pageNumber, paginator.getPageCount()))
+                                .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.right"), String.format("/chelp %d", page.pageNumber + 1))));
 
-                        return page.Items.size();
+                        return page.items.size();
                     }
                     else
                     {
@@ -113,13 +115,11 @@ public class CHelpCommand {
                 })));
     }
 
-    public static boolean isInteger(String input)
-    {
-        try
-        {
+    public static boolean isInteger(String input) {
+        try {
             Integer.parseInt(input);
             return true;
-        }catch (NumberFormatException e){
+        }catch(NumberFormatException e) {
             return false;
         }
     }

--- a/src/main/java/net/earthcomputer/clientcommands/command/CHelpCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CHelpCommand.java
@@ -8,7 +8,6 @@ import com.mojang.brigadier.tree.CommandNode;
 import net.earthcomputer.clientcommands.Page;
 import net.earthcomputer.clientcommands.Paginator;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.MinecraftClientGame;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
@@ -32,13 +31,17 @@ public class CHelpCommand {
             .executes(ctx -> {
                 int cmdCount = 0;
 
-                List<String> commandNames = new ArrayList<String>();
+                List<String> simpleList = new ArrayList<String>();
+
+                simpleList.add(new TranslatableText("commands.chelp.paging.header1").getString());
+                simpleList.add(new TranslatableText("commands.chelp.paging.header2").getString());
+
                 for(CommandNode<ServerCommandSource> command : dispatcher.getRoot().getChildren()) {
 
                     String commandName = command.getName();
 
                     if(isClientSideCommand(commandName)) {
-                        commandNames.add('/' + commandName);
+                        simpleList.add('/' + commandName);
                         cmdCount++;
                     }
 
@@ -46,7 +49,7 @@ public class CHelpCommand {
 
                 MinecraftClient.getInstance().inGameHud.getChatHud().clear(false);
 
-                Paginator<String> paginator = new Paginator<String>(commandNames, calculatePageSize());
+                Paginator<String> paginator = new Paginator<String>(simpleList, calculatePageSize());
                 Page<String> page = paginator.getPage(1);
 
                 for (int i = 0; i < page.items.size(); i++) {
@@ -69,19 +72,22 @@ public class CHelpCommand {
                     if(isInteger(userInput)) {
 
                         int userPage = Integer.parseInt(userInput);
-                        List<String> commandNames = new ArrayList<String>();
+                        List<String> simpleList = new ArrayList<String>();
+
+                        simpleList.add(new TranslatableText("commands.chelp.paging.header1").getString());
+                        simpleList.add(new TranslatableText("commands.chelp.paging.header2").getString());
 
                         for(CommandNode<ServerCommandSource> command : dispatcher.getRoot().getChildren()) {
                             String commandName = command.getName();
 
                             if(isClientSideCommand(commandName)) {
-                                commandNames.add('/' + commandName);
+                                simpleList.add('/' + commandName);
                             }
                         }
 
                         MinecraftClient.getInstance().inGameHud.getChatHud().clear(false);
 
-                        Paginator<String> paginator = new Paginator<String>(commandNames, calculatePageSize());
+                        Paginator<String> paginator = new Paginator<String>(simpleList, calculatePageSize());
 
                         if(!paginator.isValidPage(userPage)) {
                             sendFeedback(new TranslatableText("commands.chelp.paging.incorrect", userPage));

--- a/src/main/java/net/earthcomputer/clientcommands/command/CHelpCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CHelpCommand.java
@@ -41,13 +41,17 @@ public class CHelpCommand {
                     }
                 }
 
-                Paginator<String> paginator = new Paginator<String>(commandNames, 9);
+                Paginator<String> paginator = new Paginator<String>(commandNames, 19);
                 Page<String> page = paginator.getPage(1);
                 for (int i = 0; i < page.Items.size(); i++)
                 {
                     sendFeedback(page.Items.get(i));
                 }
-                sendFeedback(new TranslatableText("paginator.display.page", page.PageNumber, paginator.getPageCount()));
+
+                sendFeedback(new LiteralText("")
+                        .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.left"), String.format("/chelp %d", page.PageNumber - 1)))
+                        .append(new TranslatableText("commands.chelp.paging.body", page.PageNumber, paginator.getPageCount()))
+                        .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.right"), String.format("/chelp %d", page.PageNumber + 1))));
 
                 return cmdCount;
 
@@ -70,10 +74,10 @@ public class CHelpCommand {
                                 commandNames.add('/' + commandName);
                             }
                         }
-                        Paginator<String> paginator = new Paginator<String>(commandNames, 9);
+                        Paginator<String> paginator = new Paginator<String>(commandNames, 19);
                         if(!paginator.isValidPage(userPage))
                         {
-                            sendFeedback(new TranslatableText("paginator.incorrect.page"));
+                            sendFeedback(new TranslatableText("commands.chelp.paging.incorrect", userPage));
                             return 0;
                         }
                         Page<String> page = paginator.getPage(userPage);
@@ -82,7 +86,10 @@ public class CHelpCommand {
                             sendFeedback(page.Items.get(i));
                         }
 
-                        sendFeedback(new TranslatableText("paginator.display.page", page.PageNumber, paginator.getPageCount()));
+                        sendFeedback(new LiteralText("")
+                                .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.left"), String.format("/chelp %d", page.PageNumber - 1)))
+                                .append(new TranslatableText("commands.chelp.paging.body", page.PageNumber, paginator.getPageCount()))
+                                .append(getCommandTextComponent(new TranslatableText("commands.chelp.paging.right"), String.format("/chelp %d", page.PageNumber + 1))));
 
                         return page.Items.size();
                     }

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -76,6 +76,8 @@
   "commands.cglow.entity.success": "Glowing %d entities",
   "commands.cglow.area.success": "Glowing %d area(s)",
 
+  "commands.chelp.paging.header1": "Usage \"/chelp 1\" or \"/chelp cmote\"",
+  "commands.chelp.paging.header2": "Arrows at the bottom are clickable",
   "commands.chelp.paging.left": "<<",
   "commands.chelp.paging.right": ">>",
   "commands.chelp.paging.body": " | %d/%d | ",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -76,6 +76,11 @@
   "commands.cglow.entity.success": "Glowing %d entities",
   "commands.cglow.area.success": "Glowing %d area(s)",
 
+  "commands.chelp.paging.left": "<<",
+  "commands.chelp.paging.right": ">>",
+  "commands.chelp.paging.body": " | %d/%d | ",
+  "commands.chelp.paging.incorrect": "Page: %d does not exist",
+
   "commands.chotbar.notCreative": "Player must be in creative mode to restore item hotbars",
   "commands.chotbar.restoredHotbar": "Restored item hotbar %d",
 
@@ -150,9 +155,6 @@
   "enchCrack.insn.itemThrows": "Item throws needed: %d (about %f seconds)",
   "enchCrack.insn.itemThrows.noDummy": "No dummy enchantment",
   "enchCrack.insn.enchantments": "Enchantments on item:",
-
-  "paginator.display.page": "Page number: %d of %d",
-  "paginator.incorrect.page": "Specified page is out of bounds",
 
   "playerManip.state": "Player Crack State: %s",
   "playerManip.state.uncracked": "Uncracked",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -151,7 +151,7 @@
   "enchCrack.insn.itemThrows.noDummy": "No dummy enchantment",
   "enchCrack.insn.enchantments": "Enchantments on item:",
 
-  "paginator.display.page": "Page number %d of %d",
+  "paginator.display.page": "Page number: %d of %d",
   "paginator.incorrect.page": "Specified page is out of bounds",
 
   "playerManip.state": "Player Crack State: %s",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -151,6 +151,9 @@
   "enchCrack.insn.itemThrows.noDummy": "No dummy enchantment",
   "enchCrack.insn.enchantments": "Enchantments on item:",
 
+  "paginator.display.page": "Page number %d of %d",
+  "paginator.incorrect.page": "Specified page is out of bounds",
+
   "playerManip.state": "Player Crack State: %s",
   "playerManip.state.uncracked": "Uncracked",
   "playerManip.state.cracked": "Cracked",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -79,7 +79,7 @@
   "commands.chelp.paging.left": "<<",
   "commands.chelp.paging.right": ">>",
   "commands.chelp.paging.body": " | %d/%d | ",
-  "commands.chelp.paging.incorrect": "Page: %d does not exist",
+  "commands.chelp.paging.incorrect": "Page %d does not exist",
 
   "commands.chotbar.notCreative": "Player must be in creative mode to restore item hotbars",
   "commands.chotbar.restoredHotbar": "Restored item hotbar %d",


### PR DESCRIPTION
Since clientcommands is growing fast in features i thought that implementation of paginator would be really nice idea.
By default i set up to 9 entries per page + page number information. Minecraft allows to display 10 items without opening chatbox.
Also i removed command arguments from paginator which are still accessible within `/chelp <commandname>`

Preview: 
![1](https://user-images.githubusercontent.com/44427021/116781441-2f8adf00-aa83-11eb-93d0-17044e1b28f5.png)
![2](https://user-images.githubusercontent.com/44427021/116781443-30bc0c00-aa83-11eb-9743-a1c60d3c2979.png)
