### PR TITLE
Add the /ctp command

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -54,6 +54,7 @@ public class ClientCommands implements ClientModInitializer {
         KitCommand.register(dispatcher);
         ItemGroupCommand.register(dispatcher);
         CParticleCommand.register(dispatcher);
+        CTeleportCommand.register(dispatcher);
 
         CrackRNGCommand.register(dispatcher);
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/CTeleportCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CTeleportCommand.java
@@ -12,14 +12,11 @@ import net.minecraft.text.TranslatableText;
 import java.util.UUID;
 import java.util.stream.StreamSupport;
 
-import static net.earthcomputer.clientcommands.command.ClientCommandManager.addClientSideCommand;
-import static net.earthcomputer.clientcommands.command.arguments.ClientEntityArgumentType.entity;
-import static net.earthcomputer.clientcommands.command.arguments.ClientEntityArgumentType.getEntity;
-import static net.minecraft.command.CommandSource.suggestMatching;
-import static net.minecraft.command.argument.UuidArgumentType.getUuid;
-import static net.minecraft.command.argument.UuidArgumentType.uuid;
-import static net.minecraft.server.command.CommandManager.argument;
-import static net.minecraft.server.command.CommandManager.literal;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
+import static net.earthcomputer.clientcommands.command.arguments.ClientEntityArgumentType.*;
+import static net.minecraft.command.CommandSource.*;
+import static net.minecraft.command.argument.UuidArgumentType.*;
+import static net.minecraft.server.command.CommandManager.*;
 
 public class CTeleportCommand {
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/CTeleportCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CTeleportCommand.java
@@ -4,18 +4,14 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.entity.Entity;
 import net.minecraft.network.packet.c2s.play.SpectatorTeleportC2SPacket;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.TranslatableText;
 
 import java.util.UUID;
-import java.util.stream.StreamSupport;
 
 import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
 import static net.earthcomputer.clientcommands.command.arguments.ClientEntityArgumentType.*;
-import static net.minecraft.command.CommandSource.*;
-import static net.minecraft.command.argument.UuidArgumentType.*;
 import static net.minecraft.server.command.CommandManager.*;
 
 public class CTeleportCommand {
@@ -28,12 +24,8 @@ public class CTeleportCommand {
         addClientSideCommand("ctp");
 
         dispatcher.register(literal("ctp")
-                .then(argument("uuid", uuid())
-                        .suggests((context, builder) -> suggestMatching(client.world.getPlayers().stream().map(Entity::getUuidAsString), builder))
-                        .suggests((context, builder) -> suggestMatching(StreamSupport.stream(client.world.getEntities().spliterator(), false).map(Entity::getUuidAsString), builder))
-                        .executes(ctx -> teleport(ctx.getSource(), getUuid(ctx, "uuid"))))
-                .then(argument("player", entity())
-                        .executes(ctx -> teleport(ctx.getSource(), getEntity(ctx, "player").getUuid()))));
+                .then(argument("entity", entity())
+                        .executes(ctx -> teleport(ctx.getSource(), getEntity(ctx, "entity").getUuid()))));
     }
 
     private static int teleport(ServerCommandSource source, UUID uuid) throws CommandSyntaxException {

--- a/src/main/java/net/earthcomputer/clientcommands/command/CTeleportCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CTeleportCommand.java
@@ -1,0 +1,49 @@
+package net.earthcomputer.clientcommands.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.Entity;
+import net.minecraft.network.packet.c2s.play.SpectatorTeleportC2SPacket;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.TranslatableText;
+
+import java.util.UUID;
+import java.util.stream.StreamSupport;
+
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.addClientSideCommand;
+import static net.earthcomputer.clientcommands.command.arguments.ClientEntityArgumentType.entity;
+import static net.earthcomputer.clientcommands.command.arguments.ClientEntityArgumentType.getEntity;
+import static net.minecraft.command.CommandSource.suggestMatching;
+import static net.minecraft.command.argument.UuidArgumentType.getUuid;
+import static net.minecraft.command.argument.UuidArgumentType.uuid;
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+public class CTeleportCommand {
+
+    private static final SimpleCommandExceptionType NOT_SPECTATOR_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("command.ctp.notSpectator"));
+
+    private static final MinecraftClient client = MinecraftClient.getInstance();
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        addClientSideCommand("ctp");
+
+        dispatcher.register(literal("ctp")
+                .then(argument("uuid", uuid())
+                        .suggests((context, builder) -> suggestMatching(client.world.getPlayers().stream().map(Entity::getUuidAsString), builder))
+                        .suggests((context, builder) -> suggestMatching(StreamSupport.stream(client.world.getEntities().spliterator(), false).map(Entity::getUuidAsString), builder))
+                        .executes(ctx -> teleport(ctx.getSource(), getUuid(ctx, "uuid"))))
+                .then(argument("player", entity())
+                        .executes(ctx -> teleport(ctx.getSource(), getEntity(ctx, "player").getUuid()))));
+    }
+
+    private static int teleport(ServerCommandSource source, UUID uuid) throws CommandSyntaxException {
+        if (client.player.isSpectator()) {
+            throw NOT_SPECTATOR_EXCEPTION.create();
+        }
+        client.getNetworkHandler().sendPacket(new SpectatorTeleportC2SPacket(uuid));
+        return 0;
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/command/CTeleportCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CTeleportCommand.java
@@ -20,7 +20,7 @@ import static net.minecraft.server.command.CommandManager.*;
 
 public class CTeleportCommand {
 
-    private static final SimpleCommandExceptionType NOT_SPECTATOR_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("command.ctp.notSpectator"));
+    private static final SimpleCommandExceptionType NOT_SPECTATOR_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("commands.ctp.notSpectator"));
 
     private static final MinecraftClient client = MinecraftClient.getInstance();
 
@@ -37,10 +37,11 @@ public class CTeleportCommand {
     }
 
     private static int teleport(ServerCommandSource source, UUID uuid) throws CommandSyntaxException {
-        if (client.player.isSpectator()) {
+        if (!client.player.isSpectator()) {
             throw NOT_SPECTATOR_EXCEPTION.create();
         }
         client.getNetworkHandler().sendPacket(new SpectatorTeleportC2SPacket(uuid));
+        sendFeedback(new TranslatableText("commands.ctp.success", uuid.toString()));
         return 0;
     }
 }

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -127,6 +127,9 @@
   "commands.ctemprule.reset.success": "TempRule %s has been reset to %s",
   "commands.ctemprule.set.success": "TempRule %s has been updated to %s",
 
+  "commands.ctp.notSpectator": "Player must be in spectator mode to teleport",
+  "commands.ctp.success": "Teleported player to %s",
+
   "commands.cwiki.failed": "Could not retrieve wiki content",
 
   "commands.client.blockpos": "(%d, %d, %d)",


### PR DESCRIPTION
Closes #293.

Not only the UUIDs suggested by the client, but also any valid UUID of an entity will be valid as an argument to the command. Because UUIDs alone are quite meaningless, entity selectors are supported as well. For example, use `/ctp @e[type=minecraft:zombie, sort=furthest, limit=1]` to teleport to the furthest zombie known to the client. Sadly, one can't teleport to arbitrary coordinates.