### PR TITLE
Implement clickable Wiki Table of Contents + querying of individual wiki sections with /cwiki 

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/command/ClientCommandManager.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/ClientCommandManager.java
@@ -126,5 +126,14 @@ public class ClientCommandManager {
                 .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command))
                 .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText(command))));
     }
+    public static Text getViewWikiTOCTextComponent(TranslatableText translatableText, String pageName) {
+        return getCommandTextComponent(translatableText, String.format("/cwiki %s TOC", pageName));
+    }
+    public static Text getWikiTOCTextComponent(String pageName, String number, String line) {
+        String command = String.format("/cwiki %s %s", pageName, number);
+        return new LiteralText(Formatting.BOLD + number + Formatting.RESET + ". " + line).styled(style -> style
+                .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command))
+                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText(command))));
+    }
 
 }

--- a/src/main/java/net/earthcomputer/clientcommands/features/WikiRetriever.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/WikiRetriever.java
@@ -1,6 +1,10 @@
 package net.earthcomputer.clientcommands.features;
 
 import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
 
 import java.io.IOException;
@@ -13,15 +17,21 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
+
 public class WikiRetriever {
 
     private static final String WIKI_HOST = "https://minecraft.gamepedia.com/";
     private static final String PAGE_SUMMARY_QUERY = WIKI_HOST + "api.php?action=query&prop=extracts&exintro=true&format=json&titles=%s";
+    private static final String PAGE_TOC_PARSE = WIKI_HOST + "api.php?action=parse&prop=sections&format=json&page=%s";
+    private static final String PAGE_SECTION_PARSE = WIKI_HOST + "api.php?action=parse&prop=text&format=json&page=%s&section=%s&disablelimitreport=true&disableeditsection=true";
     private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<\\s*(/)?\\s*(\\w+).*?>", Pattern.DOTALL);
     private static final Formatting CODE_COLOR = Formatting.DARK_GREEN;
     private static final Gson GSON = new Gson();
 
     public static String decode(String html) {
+        html = html.replaceAll("<span class=\"sprite inv-sprite\" title=\"(.*?)\".*?</span>", "$1 ");
+
         Matcher matcher = HTML_TAG_PATTERN.matcher(html);
         StringBuffer raw = new StringBuffer();
 
@@ -38,6 +48,7 @@ public class WikiRetriever {
 
             if (!endTag) {
                 switch (tagName) {
+                    case "th": //fallthrough
                     case "b":
                         raw.append(Formatting.BOLD);
                         bold = true;
@@ -80,6 +91,9 @@ public class WikiRetriever {
                 }
             } else {
                 switch (tagName) {
+                    case "th":
+                        raw.append(" ");
+                        //fallthrough
                     case "b":
                         if (code) raw.append(CODE_COLOR);
                         else raw.append(Formatting.RESET);
@@ -132,6 +146,8 @@ public class WikiRetriever {
         rawStr = rawStr.replace("&lt;", "<");
         rawStr = rawStr.replace("&gt;", ">");
         rawStr = rawStr.replace("&amp;", "&");
+        rawStr = rawStr.replaceAll("&#160;(or|\\+)\n", " $1 ");
+        rawStr = rawStr.replaceAll("\\n(§.)", "$1");
 
         return rawStr;
     }
@@ -145,9 +161,9 @@ public class WikiRetriever {
             return null;
         }
 
-        QueryResult result;
+        SummaryQueryResult result;
         try (InputStream in = url.openConnection().getInputStream()) {
-            result = GSON.fromJson(new InputStreamReader(in), QueryResult.class);
+            result = GSON.fromJson(new InputStreamReader(in), SummaryQueryResult.class);
         } catch (IOException e) {
             return null;
         }
@@ -161,7 +177,89 @@ public class WikiRetriever {
         return decode(html);
     }
 
-    private static class QueryResult {
+    public static ParseTOCResult getTOCData(String pageName) {
+        URL url;
+        try {
+            String encodedPage = URLEncoder.encode(pageName, "UTF-8");
+            url = new URL(String.format(PAGE_TOC_PARSE, encodedPage));
+            sendFeedback("TOCData url:" + url.toString());
+        } catch (UnsupportedEncodingException | MalformedURLException e) {
+            return null;
+        }
+        sendFeedback("is this how to debug?v9");
+        ParseTOCResult result;
+        try (InputStream in = url.openConnection().getInputStream()) {
+            sendFeedback("is this how to debug?v10");
+            result = GSON.fromJson(new InputStreamReader(in), ParseTOCResult.class);
+            sendFeedback("is this how to debug?v11");
+        } catch (IOException e) {
+            sendFeedback("is this how to debug?v12");
+            return null;
+        }
+        sendFeedback("is this how to debug?v13");
+        if (result.error != null || result.parse.sections.length == 0) {
+            return null;
+        }
+        sendFeedback("is this how to debug?v14");
+        return result;
+    }
+
+    public static void displayWikiTOC(String pageName) {
+
+        ParseTOCResult TOCData = getTOCData(pageName);
+        if(TOCData == null) {
+            sendError(new TranslatableText("commands.cwiki.failed"));
+            return;
+        }
+
+        MutableText toc = new LiteralText("");
+        for (ParseTOCResult.Parse.Section currentSection : TOCData.parse.sections) {
+            toc.append("\n");
+            for (int i = 1; i < currentSection.toclevel; i++) { toc.append(" "); }
+            toc.append(getWikiTOCTextComponent(pageName, currentSection.number, currentSection.line));
+        }
+        sendFeedback(toc);
+    }
+    public static String getSectionIndex(String pageName, String section) {
+        ParseTOCResult TOCData = getTOCData(pageName);
+        if (TOCData == null) return null;
+        for (ParseTOCResult.Parse.Section currentSection : TOCData.parse.sections) {
+            if(currentSection.anchor.equals(section) || currentSection.number.equals(section)) {
+                return currentSection.index;
+            }
+        }
+        return "0";
+    }
+
+    public static String getWikiSection(String pageName, String section) {
+
+        String sectionIndex = getSectionIndex(pageName, section);
+        URL url;
+        try {
+            String encodedPage = URLEncoder.encode(pageName, "UTF-8");
+            url = new URL(String.format(PAGE_SECTION_PARSE, encodedPage, sectionIndex));
+            sendFeedback(url.toString());
+        } catch (UnsupportedEncodingException | MalformedURLException e) {
+            return null;
+        }
+
+        ParseSectionResult result;
+        try (InputStream in = url.openConnection().getInputStream()) {
+            sendFeedback("is this how to debug?");
+            result = GSON.fromJson(new InputStreamReader(in), ParseSectionResult.class);
+            sendFeedback("is this how to debug? v2");
+        } catch (IOException e) {
+            return null;
+        }
+
+        if (result.error != null || result.parse.text.section == null)
+            return null;
+        String html = result.parse.text.section;
+        sendFeedback("is this how to debug?v4");
+        return decode(html);
+    }
+
+    private static class SummaryQueryResult {
         public String batchcomplete;
         public Query query;
         private static class Query {
@@ -171,6 +269,33 @@ public class WikiRetriever {
                 public String title;
                 public String extract;
                 public String missing;
+            }
+        }
+    }
+
+    private static class ParseSectionResult {
+        public Object error;
+        public Parse parse;
+        private static class Parse {
+            public String title;
+            public Text text;
+            private static class Text {
+                @SerializedName("*") public String section;
+            }
+        }
+    }
+
+    private static class ParseTOCResult {
+        public Object error;
+        public Parse parse;
+        private static class Parse {
+            private Section sections[];
+            private static class Section {
+                public int toclevel;
+                public String index;
+                public String line;
+                public String number;
+                public String anchor;
             }
         }
     }

--- a/src/main/java/net/earthcomputer/clientcommands/features/WikiRetriever.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/WikiRetriever.java
@@ -182,25 +182,22 @@ public class WikiRetriever {
         try {
             String encodedPage = URLEncoder.encode(pageName, "UTF-8");
             url = new URL(String.format(PAGE_TOC_PARSE, encodedPage));
-            sendFeedback("TOCData url:" + url.toString());
+            // sendFeedback("TOCData url:" + url.toString());
         } catch (UnsupportedEncodingException | MalformedURLException e) {
             return null;
         }
-        sendFeedback("is this how to debug?v9");
+
         ParseTOCResult result;
         try (InputStream in = url.openConnection().getInputStream()) {
-            sendFeedback("is this how to debug?v10");
             result = GSON.fromJson(new InputStreamReader(in), ParseTOCResult.class);
-            sendFeedback("is this how to debug?v11");
         } catch (IOException e) {
-            sendFeedback("is this how to debug?v12");
             return null;
         }
-        sendFeedback("is this how to debug?v13");
+
         if (result.error != null || result.parse.sections.length == 0) {
             return null;
         }
-        sendFeedback("is this how to debug?v14");
+
         return result;
     }
 
@@ -238,16 +235,14 @@ public class WikiRetriever {
         try {
             String encodedPage = URLEncoder.encode(pageName, "UTF-8");
             url = new URL(String.format(PAGE_SECTION_PARSE, encodedPage, sectionIndex));
-            sendFeedback(url.toString());
+            // sendFeedback("Section URL:" + url.toString());
         } catch (UnsupportedEncodingException | MalformedURLException e) {
             return null;
         }
 
         ParseSectionResult result;
         try (InputStream in = url.openConnection().getInputStream()) {
-            sendFeedback("is this how to debug?");
             result = GSON.fromJson(new InputStreamReader(in), ParseSectionResult.class);
-            sendFeedback("is this how to debug? v2");
         } catch (IOException e) {
             return null;
         }
@@ -255,7 +250,6 @@ public class WikiRetriever {
         if (result.error != null || result.parse.text.section == null)
             return null;
         String html = result.parse.text.section;
-        sendFeedback("is this how to debug?v4");
         return decode(html);
     }
 

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -128,6 +128,7 @@
   "commands.ctemprule.set.success": "TempRule %s has been updated to %s",
 
   "commands.cwiki.failed": "Could not retrieve wiki content",
+  "commands.cwiki.viewTOC": "[View Table of Contents]",
 
   "commands.client.blockpos": "(%d, %d, %d)",
   "commands.client.cancel": "Cancel",


### PR DESCRIPTION
(Partial) Implementation of my proposal from #274. 
Most "regular" pages like items, blocks, mobs etc. work well. Formatting could be improved in certain aspects, especially when it comes to complicated pages/large tables (smaller ones like `/cwiki beacon Range` or `/cwiki cobblestone 0` work well enough)

Paging/scrolling is not yet implemented.

EDIT: other clarifications: 

- In order to be able to add a second parameter, the page name now has to be one `snake_case` word. 
- The page name is partially case sensitive; the first character can be arbitrarily capitalized, the rest have to be identical
- It does not currently handle redirects well, `/cwiki Zombie_Pigman` for example produces a blank output.
- The `section` parameter can be either a number or a corresponding subheading, specifying anything else reverts to an index of 0 which gives you infobox info + hatnotes (currently some slight parsing/formatting issue there)