### PR TITLE
Use colors to differentiate between nesting levels in expression parsing

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/command/CalcCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CalcCommand.java
@@ -35,7 +35,7 @@ public class CalcCommand {
         if (getFlag(source, FLAG_PARSE)) {
             Text parsedTree;
             try {
-                parsedTree = expression.getParsedTree();
+                parsedTree = expression.getParsedTree(0);
             } catch (StackOverflowError e) {
                 throw TOO_DEEPLY_NESTED_EXCEPTION.create();
             }

--- a/src/main/java/net/earthcomputer/clientcommands/command/arguments/ExpressionArgumentType.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/arguments/ExpressionArgumentType.java
@@ -11,6 +11,7 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.earthcomputer.clientcommands.TempRules;
+import net.earthcomputer.clientcommands.mixin.CommandSuggestorAccessor;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.*;
@@ -279,7 +280,12 @@ public class ExpressionArgumentType implements ArgumentType<ExpressionArgumentTy
     public static abstract class Expression {
         public String strVal;
         public abstract double eval() throws StackOverflowError;
-        public abstract Text getParsedTree() throws StackOverflowError;
+        public abstract Text getParsedTree(int depth) throws StackOverflowError;
+
+        protected static Text getDepthStyled(int depth, MutableText text) {
+            List<Style> formattings = CommandSuggestorAccessor.getHIGHLIGHT_FORMATTINGS();
+            return text.setStyle(formattings.get(depth % formattings.size()));
+        }
     }
 
     private static class BinaryOpExpression extends Expression {
@@ -301,8 +307,8 @@ public class ExpressionArgumentType implements ArgumentType<ExpressionArgumentTy
         }
 
         @Override
-        public Text getParsedTree() {
-            return new TranslatableText("commands.ccalc.parse.binaryOperator." + type, left.getParsedTree(), right.getParsedTree());
+        public Text getParsedTree(int depth) {
+            return getDepthStyled(depth, new TranslatableText("commands.ccalc.parse.binaryOperator." + type, left.getParsedTree(depth + 1), right.getParsedTree(depth + 1)));
         }
     }
 
@@ -319,8 +325,8 @@ public class ExpressionArgumentType implements ArgumentType<ExpressionArgumentTy
         }
 
         @Override
-        public Text getParsedTree() {
-            return new TranslatableText("commands.ccalc.parse.negate", this.right.getParsedTree());
+        public Text getParsedTree(int depth) {
+            return getDepthStyled(depth, new TranslatableText("commands.ccalc.parse.negate", this.right.getParsedTree(depth + 1)));
         }
     }
 
@@ -346,8 +352,8 @@ public class ExpressionArgumentType implements ArgumentType<ExpressionArgumentTy
         }
 
         @Override
-        public Text getParsedTree() {
-            return new TranslatableText("commands.ccalc.parse.constant", this.type);
+        public Text getParsedTree(int depth) {
+            return getDepthStyled(depth, new TranslatableText("commands.ccalc.parse.constant", this.type));
         }
     }
 
@@ -440,7 +446,7 @@ public class ExpressionArgumentType implements ArgumentType<ExpressionArgumentTy
         }
 
         @Override
-        public Text getParsedTree() {
+        public Text getParsedTree(int depth) {
             MutableText argumentsText = new LiteralText("");
             boolean first = true;
             for (Expression argument : this.arguments) {
@@ -450,10 +456,10 @@ public class ExpressionArgumentType implements ArgumentType<ExpressionArgumentTy
                     argumentsText.append(", ");
                 }
 
-                argumentsText.append(argument.getParsedTree());
+                argumentsText.append(argument.getParsedTree(depth + 1));
             }
 
-            return new TranslatableText("commands.ccalc.parse.function", this.type, argumentsText);
+            return getDepthStyled(depth, new TranslatableText("commands.ccalc.parse.function", this.type, argumentsText));
         }
 
         private static interface IFunction {
@@ -514,8 +520,8 @@ public class ExpressionArgumentType implements ArgumentType<ExpressionArgumentTy
         }
 
         @Override
-        public Text getParsedTree() {
-            return new TranslatableText("commands.ccalc.parse.literal", this.val);
+        public Text getParsedTree(int depth) {
+            return getDepthStyled(depth, new TranslatableText("commands.ccalc.parse.literal", this.val));
         }
     }
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/arguments/ExpressionArgumentType.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/arguments/ExpressionArgumentType.java
@@ -283,7 +283,7 @@ public class ExpressionArgumentType implements ArgumentType<ExpressionArgumentTy
         public abstract Text getParsedTree(int depth) throws StackOverflowError;
 
         protected static Text getDepthStyled(int depth, MutableText text) {
-            List<Style> formattings = CommandSuggestorAccessor.getHIGHLIGHT_FORMATTINGS();
+            List<Style> formattings = CommandSuggestorAccessor.getHighlightFormattings();
             return text.setStyle(formattings.get(depth % formattings.size()));
         }
     }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/CommandSuggestorAccessor.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/CommandSuggestorAccessor.java
@@ -1,0 +1,17 @@
+package net.earthcomputer.clientcommands.mixin;
+
+import java.util.List;
+import net.minecraft.client.gui.screen.CommandSuggestor;
+import net.minecraft.text.Style;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(CommandSuggestor.class)
+public interface CommandSuggestorAccessor {
+
+    @Accessor
+    static List<Style> getHIGHLIGHT_FORMATTINGS() {
+        throw new AssertionError();
+    }
+
+}

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/CommandSuggestorAccessor.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/CommandSuggestorAccessor.java
@@ -9,8 +9,8 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 @Mixin(CommandSuggestor.class)
 public interface CommandSuggestorAccessor {
 
-    @Accessor
-    static List<Style> getHIGHLIGHT_FORMATTINGS() {
+    @Accessor("HIGHLIGHT_FORMATTINGS")
+    static List<Style> getHighlightFormattings() {
         throw new AssertionError();
     }
 

--- a/src/main/resources/mixins.clientcommands.json
+++ b/src/main/resources/mixins.clientcommands.json
@@ -62,7 +62,8 @@
     "ProjectileEntityAccessor",
     "ScreenHandlerAccessor",
     "MixinItemGroup",
-    "CreativeInventoryScreenAccessor"
+    "CreativeInventoryScreenAccessor",
+    "CommandSuggestorAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fixes #304

![](https://user-images.githubusercontent.com/24855774/128458191-b76e1f91-2f3a-4646-b79f-54969a179904.png)
