### PR TITLE
fix and simplify line rendering

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinGameRenderer.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinGameRenderer.java
@@ -2,13 +2,10 @@ package net.earthcomputer.clientcommands.mixin;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.earthcomputer.clientcommands.render.RenderQueue;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.render.BufferBuilderStorage;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.GameRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Vec3d;
-import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -18,21 +15,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
 public abstract class MixinGameRenderer {
-    @Shadow @Final private BufferBuilderStorage buffers;
     @Shadow @Final private Camera camera;
 
     @Inject(method = "renderWorld", at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiler/Profiler;swap(Ljava/lang/String;)V", args = {"ldc=hand"}))
     private void renderWorldHand(float delta, long time, MatrixStack matrixStack, CallbackInfo ci) {
         matrixStack.push();
 
-        // Render lines through everything
-        // TODO: is this the best approach to render through blocks?
-        RenderSystem.clear(GL11.GL_DEPTH_BUFFER_BIT, MinecraftClient.IS_SYSTEM_MAC);
-
         Vec3d cameraPos = camera.getPos();
         matrixStack.translate(-cameraPos.x, -cameraPos.y, -cameraPos.z);
         RenderSystem.disableDepthTest();
-        RenderQueue.render(RenderQueue.Layer.ON_TOP, matrixStack, buffers.getEntityVertexConsumers(), delta);
+        RenderQueue.render(RenderQueue.Layer.ON_TOP, matrixStack, delta);
         RenderSystem.enableDepthTest();
 
         matrixStack.pop();

--- a/src/main/java/net/earthcomputer/clientcommands/render/Cuboid.java
+++ b/src/main/java/net/earthcomputer/clientcommands/render/Cuboid.java
@@ -1,9 +1,7 @@
 package net.earthcomputer.clientcommands.render;
 
 
-import net.minecraft.client.render.RenderLayer;
-import net.minecraft.client.render.VertexConsumer;
-import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
@@ -36,12 +34,13 @@ public class Cuboid extends Shape {
     }
 
     @Override
-    public void render(MatrixStack matrixStack, VertexConsumerProvider.Immediate vertexConsumerProvider, float delta) {
-        VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(RenderLayer.getLines());
+    public void render(MatrixStack matrixStack, float delta) {
+        BufferBuilder buff = Tessellator.getInstance().getBuffer();
+        buff.begin(VertexFormat.DrawMode.DEBUG_LINES, VertexFormats.POSITION_COLOR);
         for (Line edge : this.edges) {
-            edge.renderLine(matrixStack, vertexConsumer, delta, prevPos.subtract(getPos()));
+            edge.renderLine(matrixStack, buff, delta, prevPos.subtract(getPos()));
         }
-        vertexConsumerProvider.draw(RenderLayer.getLines());
+        Tessellator.getInstance().draw();
     }
 
     @Override

--- a/src/main/java/net/earthcomputer/clientcommands/render/Line.java
+++ b/src/main/java/net/earthcomputer/clientcommands/render/Line.java
@@ -1,9 +1,7 @@
 package net.earthcomputer.clientcommands.render;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraft.client.render.RenderLayer;
-import net.minecraft.client.render.VertexConsumer;
-import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Vec3d;
 
@@ -25,10 +23,11 @@ public class Line extends Shape {
     }
 
     @Override
-    public void render(MatrixStack matrixStack, VertexConsumerProvider.Immediate vertexConsumerProvider, float delta) {
-        VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(RenderLayer.getLines());
-        renderLine(matrixStack, vertexConsumer, delta, prevPos.subtract(getPos()));
-        vertexConsumerProvider.draw(RenderLayer.getLines());
+    public void render(MatrixStack matrixStack, float delta) {
+        BufferBuilder buff = Tessellator.getInstance().getBuffer();
+        buff.begin(VertexFormat.DrawMode.DEBUG_LINES, VertexFormats.POSITION_COLOR);
+        renderLine(matrixStack, buff, delta, prevPos.subtract(getPos()));
+        Tessellator.getInstance().draw();
     }
 
     public void renderLine(MatrixStack matrixStack, VertexConsumer vertexConsumer, float delta, Vec3d prevPosOffset) {
@@ -49,8 +48,6 @@ public class Line extends Shape {
                 ((color >> 8) & 0xFF) / 255.0F,
                 (color & 0xFF) / 255.0F,
                 1.0F
-        ).normal(
-                1, 0, 0
         ).next();
     }
 

--- a/src/main/java/net/earthcomputer/clientcommands/render/RenderQueue.java
+++ b/src/main/java/net/earthcomputer/clientcommands/render/RenderQueue.java
@@ -1,6 +1,5 @@
 package net.earthcomputer.clientcommands.render;
 
-import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
@@ -64,9 +63,9 @@ public class RenderQueue {
         }
     }
 
-    public static void render(Layer layer, MatrixStack matrixStack, VertexConsumerProvider.Immediate vertexConsumerProvider, float delta) {
+    public static void render(Layer layer, MatrixStack matrixStack, float delta) {
         if (!queue.containsKey(layer)) return;
-        queue.get(layer).values().forEach(shape -> shape.render(matrixStack, vertexConsumerProvider, delta));
+        queue.get(layer).values().forEach(shape -> shape.render(matrixStack, delta));
     }
 
     public enum Layer {

--- a/src/main/java/net/earthcomputer/clientcommands/render/Shape.java
+++ b/src/main/java/net/earthcomputer/clientcommands/render/Shape.java
@@ -1,5 +1,6 @@
 package net.earthcomputer.clientcommands.render;
 
+import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.math.Vec3d;
@@ -11,7 +12,7 @@ public abstract class Shape {
     public void tick() {
     }
 
-    public abstract void render(MatrixStack matrixStack, VertexConsumerProvider.Immediate vertexConsumerProvider, float delta);
+    public abstract void render(MatrixStack matrixStack, float delta);
 
     public abstract Vec3d getPos();
 


### PR DESCRIPTION
fixes #269 and #313

Best I can tell, the default Line layer enables depth when put as the active Immediate buffer...
so I set up and teardown/draw the buffers directly using `Tessellator`.