### PR TITLE
Add a "usage tree" command.

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -34,6 +34,7 @@ public class ClientCommands implements ClientModInitializer {
         TempRuleCommand.register(dispatcher);
         RenderCommand.register(dispatcher);
         CHelpCommand.register(dispatcher);
+        UsageTreeCommand.register(dispatcher);
         WikiCommand.register(dispatcher);
         CEnchantCommand.register(dispatcher);
         GlowCommand.register(dispatcher);

--- a/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.tree.CommandNode;
+import net.minecraft.command.CommandSource;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
@@ -34,11 +35,9 @@ public class UsageTreeCommand {
                     return content.size() + 1;
                 })
                 .then(argument("command", greedyString())
+                    .suggests((ctx, builder) -> CommandSource.suggestMatching(dispatcher.getRoot().getChildren().stream().map(CommandNode::getUsageText).toList(), builder))
                     .executes(ctx -> {
                         String cmdName = getString(ctx, "command");
-                        if (!isClientSideCommand(cmdName)) {
-                            throw FAILED_EXCEPTION.create();
-                        }
                         var parseResults = dispatcher.parse(cmdName, ctx.getSource());
                         if (parseResults.getContext().getNodes().isEmpty()) {
                             throw FAILED_EXCEPTION.create();

--- a/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
@@ -16,12 +16,14 @@ import java.util.List;
 
 import static com.mojang.brigadier.arguments.StringArgumentType.getString;
 import static com.mojang.brigadier.arguments.StringArgumentType.greedyString;
-import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.addClientSideCommand;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.sendFeedback;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
 
 public class UsageTreeCommand {
-    private static final SimpleCommandExceptionType FAILED_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("commands.helptree.failed"));
+    private static final SimpleCommandExceptionType FAILED_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText(
+        "commands.helptree.failed"));
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         addClientSideCommand("cusagetree");
@@ -37,7 +39,11 @@ public class UsageTreeCommand {
                     return content.size() + 1;
                 })
                 .then(argument("command", greedyString())
-                    .suggests((ctx, builder) -> CommandSource.suggestMatching(dispatcher.getRoot().getChildren().stream().map(CommandNode::getUsageText).toList(), builder))
+                    .suggests((ctx, builder) -> CommandSource.suggestMatching(dispatcher.getRoot()
+                        .getChildren()
+                        .stream()
+                        .map(CommandNode::getUsageText)
+                        .toList(), builder))
                     .executes(ctx -> {
                         String cmdName = getString(ctx, "command");
                         var parseResults = dispatcher.parse(cmdName, ctx.getSource());
@@ -60,11 +66,15 @@ public class UsageTreeCommand {
         var children = List.copyOf(root.getChildren());
         for (int i = 0; i < children.size(); i++) {
             var child = children.get(i);
-            var childName = new LiteralText(child.getUsageText()).styled(s -> s.withColor(child.getCommand() != null ? Formatting.GREEN : Formatting.WHITE));
+            var childName = new LiteralText(child.getUsageText()).styled(s -> s.withColor(
+                child.getCommand() != null ? Formatting.GREEN : Formatting.WHITE
+            ));
             var childLines = tree(child);
             if (i + 1 < children.size()) {
                 lines.add(new LiteralText("├─ ").styled(s -> s.withColor(Formatting.GRAY)).append(childName));
-                lines.addAll(childLines.stream().map(line -> new LiteralText("│  ").styled(s -> s.withColor(Formatting.GRAY)).append(line)).toList());
+                lines.addAll(childLines.stream()
+                    .map(line -> new LiteralText("│  ").styled(s -> s.withColor(Formatting.GRAY)).append(line))
+                    .toList());
             } else {
                 lines.add(new LiteralText("└─ ").styled(s -> s.withColor(Formatting.GRAY)).append(childName));
                 lines.addAll(childLines.stream().map(line -> new LiteralText("   ").append(line)).toList());
@@ -72,4 +82,5 @@ public class UsageTreeCommand {
         }
         return lines;
     }
+
 }

--- a/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
@@ -1,0 +1,74 @@
+package net.earthcomputer.clientcommands.command;
+
+import com.google.common.collect.Iterables;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.tree.CommandNode;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.TranslatableText;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mojang.brigadier.arguments.StringArgumentType.getString;
+import static com.mojang.brigadier.arguments.StringArgumentType.greedyString;
+import static net.earthcomputer.clientcommands.command.ClientCommandManager.*;
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+public class UsageTreeCommand {
+    private static final SimpleCommandExceptionType FAILED_EXCEPTION = new SimpleCommandExceptionType(new TranslatableText("commands.helptree.failed"));
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        addClientSideCommand("cusagetree");
+
+        dispatcher.register(
+            literal("cusagetree")
+                .executes(ctx -> {
+                    var content = tree(dispatcher.getRoot());
+                    sendFeedback(new LiteralText("/"));
+                    for (var line : content) {
+                        sendFeedback(new LiteralText(line));
+                    }
+                    return content.size() + 1;
+                })
+                .then(argument("command", greedyString())
+                    .executes(ctx -> {
+                        String cmdName = getString(ctx, "command");
+                        if (!isClientSideCommand(cmdName)) {
+                            throw FAILED_EXCEPTION.create();
+                        }
+                        var parseResults = dispatcher.parse(cmdName, ctx.getSource());
+                        if (parseResults.getContext().getNodes().isEmpty()) {
+                            throw FAILED_EXCEPTION.create();
+                        }
+                        var content = tree(Iterables.getLast(parseResults.getContext().getNodes()).getNode());
+                        sendFeedback(new LiteralText("/" + cmdName));
+                        for (var line : content) {
+                            sendFeedback(new LiteralText(line));
+                        }
+                        return content.size() + 1;
+                    })
+                )
+        );
+    }
+
+    public static List<String> tree(CommandNode<?> root) {
+        List<String> lines = new ArrayList<>();
+        var children = List.copyOf(root.getChildren());
+        for (int i = 0; i < children.size(); i++) {
+            var child = children.get(i);
+            var childName = child.getUsageText();
+            var childLines = tree(child);
+            if (i + 1 < children.size()) {
+                lines.add("├── " + childName);
+                lines.addAll(childLines.stream().map(line -> "│   " + line).toList());
+            } else {
+                lines.add("└── " + childName);
+                lines.addAll(childLines.stream().map(line -> "    " + line).toList());
+            }
+        }
+        return lines;
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
@@ -7,7 +7,9 @@ import com.mojang.brigadier.tree.CommandNode;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +32,7 @@ public class UsageTreeCommand {
                     var content = tree(dispatcher.getRoot());
                     sendFeedback(new LiteralText("/"));
                     for (var line : content) {
-                        sendFeedback(new LiteralText(line));
+                        sendFeedback(line);
                     }
                     return content.size() + 1;
                 })
@@ -45,7 +47,7 @@ public class UsageTreeCommand {
                         var content = tree(Iterables.getLast(parseResults.getContext().getNodes()).getNode());
                         sendFeedback(new LiteralText("/" + cmdName));
                         for (var line : content) {
-                            sendFeedback(new LiteralText(line));
+                            sendFeedback(line);
                         }
                         return content.size() + 1;
                     })
@@ -53,19 +55,19 @@ public class UsageTreeCommand {
         );
     }
 
-    public static List<String> tree(CommandNode<?> root) {
-        List<String> lines = new ArrayList<>();
+    public static List<Text> tree(CommandNode<?> root) {
+        List<Text> lines = new ArrayList<>();
         var children = List.copyOf(root.getChildren());
         for (int i = 0; i < children.size(); i++) {
             var child = children.get(i);
-            var childName = child.getUsageText();
+            var childName = new LiteralText(child.getUsageText()).styled(s -> s.withColor(child.getCommand() != null ? Formatting.GREEN : Formatting.WHITE));
             var childLines = tree(child);
             if (i + 1 < children.size()) {
-                lines.add("├── " + childName);
-                lines.addAll(childLines.stream().map(line -> "│   " + line).toList());
+                lines.add(new LiteralText("├─ ").styled(s -> s.withColor(Formatting.GRAY)).append(childName));
+                lines.addAll(childLines.stream().map(line -> new LiteralText("│  ").styled(s -> s.withColor(Formatting.GRAY)).append(line)).toList());
             } else {
-                lines.add("└── " + childName);
-                lines.addAll(childLines.stream().map(line -> "    " + line).toList());
+                lines.add(new LiteralText("└─ ").styled(s -> s.withColor(Formatting.GRAY)).append(childName));
+                lines.addAll(childLines.stream().map(line -> new LiteralText("   ").append(line)).toList());
             }
         }
         return lines;

--- a/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/UsageTreeCommand.java
@@ -58,8 +58,9 @@ public class UsageTreeCommand {
         if (parseResults.getContext().getNodes().isEmpty()) {
             throw FAILED_EXCEPTION.create();
         }
-        var content = tree(Iterables.getLast(parseResults.getContext().getNodes()).getNode());
-        sendFeedback(new LiteralText("/" + cmdName));
+        var node = Iterables.getLast(parseResults.getContext().getNodes()).getNode();
+        var content = tree(node);
+        sendFeedback(new LiteralText("/" + cmdName).styled(s -> s.withColor(node.getCommand() != null ? Formatting.GREEN : Formatting.WHITE)));
         for (var line : content) {
             sendFeedback(line);
         }
@@ -71,9 +72,9 @@ public class UsageTreeCommand {
         var children = List.copyOf(root.getChildren());
         for (int i = 0; i < children.size(); i++) {
             var child = children.get(i);
-            var childName = new LiteralText(child.getUsageText()).styled(s -> s.withColor(
-                child.getCommand() != null ? Formatting.GREEN : Formatting.WHITE
-            ));
+            var childName = new LiteralText(child.getUsageText()).styled(s ->
+                s.withColor(child.getCommand() != null ? Formatting.GREEN : Formatting.WHITE)
+            );
             var childLines = tree(child);
             if (i + 1 < children.size()) {
                 lines.add(new LiteralText("├─ ").styled(s -> s.withColor(Formatting.GRAY)).append(childName));


### PR DESCRIPTION
adds a command which generates trees representing the usage of other commands.
result of `/cusagetree cglow`:
![image](https://user-images.githubusercontent.com/6234704/148472323-7e277e39-0d36-4215-b4de-e7438c3385a1.png)
![image](https://user-images.githubusercontent.com/6234704/148472422-91584039-05c7-42de-abba-cca570ac08a0.png)

the green represents that a command can terminate (execute) on that arg
