### PR TITLE
prevent null player from crashing

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/features/RenderSettings.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/RenderSettings.java
@@ -3,6 +3,7 @@ package net.earthcomputer.clientcommands.features;
 import net.earthcomputer.clientcommands.command.ClientEntitySelector;
 import net.earthcomputer.clientcommands.command.FakeCommandSource;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.util.Pair;
@@ -34,7 +35,9 @@ public class RenderSettings {
     }
 
     public static void preRenderEntities() {
-        ServerCommandSource source = new FakeCommandSource(MinecraftClient.getInstance().player);
+        ClientPlayerEntity player = MinecraftClient.getInstance().player;
+        if (player == null) return;
+        ServerCommandSource source = new FakeCommandSource(player);
 
         disabledEntities.clear();
         for (var filter : entityRenderSelectors) {

--- a/src/main/java/net/earthcomputer/clientcommands/features/RenderSettings.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/RenderSettings.java
@@ -36,6 +36,7 @@ public class RenderSettings {
 
     public static void preRenderEntities() {
         ClientPlayerEntity player = MinecraftClient.getInstance().player;
+        // prevent crash from other mods trying to load entity rendering without a world (usually a fake world and no client player)
         if (player == null) return;
         ServerCommandSource source = new FakeCommandSource(player);
 


### PR DESCRIPTION
(when other mods run the entity renderer without a world)
fixes #354 (yes I actually checked...)