### PR TITLE
Add `/ctime set` command

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/command/CTimeCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CTimeCommand.java
@@ -10,8 +10,10 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.command.argument.TimeArgumentType;
 import net.minecraft.text.TranslatableText;
 
+import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
 import static net.earthcomputer.clientcommands.command.ClientCommandHelper.*;
 import static net.fabricmc.fabric.api.client.command.v1.ClientCommandManager.*;
+import static net.minecraft.command.argument.TimeArgumentType.time;
 
 public class CTimeCommand {
 
@@ -35,8 +37,8 @@ public class CTimeCommand {
                     .executes(ctx -> executeSetTime(13000)))
                 .then(literal("midnight")
                     .executes(ctx -> executeSetTime(18000)))
-                .then(argument("time", TimeArgumentType.time())
-                    .executes(ctx -> executeSetTime(IntegerArgumentType.getInteger(ctx, "time")))))
+                .then(argument("time", time())
+                    .executes(ctx -> executeSetTime(getInteger(ctx, "time")))))
              .then(literal("reset")
                      .executes(ctx -> executeResetTime())) 
         );

--- a/src/main/java/net/earthcomputer/clientcommands/command/CTimeCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CTimeCommand.java
@@ -1,9 +1,13 @@
 package net.earthcomputer.clientcommands.command;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+
+import net.earthcomputer.clientcommands.features.ClientTimeModifier;
 import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.command.argument.TimeArgumentType;
 import net.minecraft.text.TranslatableText;
 
 import static net.earthcomputer.clientcommands.command.ClientCommandHelper.*;
@@ -21,7 +25,21 @@ public class CTimeCommand {
                 .then(literal("daytime")
                     .executes(ctx -> executeQueryDayTime()))
                 .then(literal("gametime")
-                    .executes(ctx -> executeQueryGameTime()))));
+                    .executes(ctx -> executeQueryGameTime())))
+            .then(literal("set")
+                .then(literal("day")
+                    .executes(ctx -> executeSetTime(1000)))
+                .then(literal("noon")
+                    .executes(ctx -> executeSetTime(6000)))
+                .then(literal("night")
+                    .executes(ctx -> executeSetTime(13000)))
+                .then(literal("midnight")
+                    .executes(ctx -> executeSetTime(18000)))
+                .then(argument("time", TimeArgumentType.time())
+                    .executes(ctx -> executeSetTime(IntegerArgumentType.getInteger(ctx, "time")))))
+             .then(literal("reset")
+                     .executes(ctx -> executeResetTime())) 
+        );
     }
 
     private static int executeQueryDay() {
@@ -40,5 +58,14 @@ public class CTimeCommand {
         sendFeedback(new TranslatableText("commands.time.query", time));
         return time;
     }
-
+    
+    private static int executeSetTime(int time) {
+        ClientTimeModifier.lock(time);
+        return executeQueryDayTime();
+    }
+    
+    private static int executeResetTime() {
+        ClientTimeModifier.none();
+        return executeQueryDayTime();
+    }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/command/CTimeCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CTimeCommand.java
@@ -1,19 +1,17 @@
 package net.earthcomputer.clientcommands.command;
 
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
-
 import net.earthcomputer.clientcommands.features.ClientTimeModifier;
 import net.fabricmc.fabric.api.client.command.v1.FabricClientCommandSource;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.command.argument.TimeArgumentType;
 import net.minecraft.text.TranslatableText;
 
 import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
-import static net.earthcomputer.clientcommands.command.ClientCommandHelper.*;
-import static net.fabricmc.fabric.api.client.command.v1.ClientCommandManager.*;
-import static net.minecraft.command.argument.TimeArgumentType.time;
+import static dev.xpple.clientarguments.arguments.CTimeArgumentType.time;
+import static net.earthcomputer.clientcommands.command.ClientCommandHelper.sendFeedback;
+import static net.fabricmc.fabric.api.client.command.v1.ClientCommandManager.argument;
+import static net.fabricmc.fabric.api.client.command.v1.ClientCommandManager.literal;
 
 public class CTimeCommand {
 

--- a/src/main/java/net/earthcomputer/clientcommands/features/ClientTimeModifier.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/ClientTimeModifier.java
@@ -1,0 +1,34 @@
+package net.earthcomputer.clientcommands.features;
+
+public class ClientTimeModifier {
+
+    public static enum Type {
+        NONE, OFFSET, LOCK;
+    }
+
+    private static Type type = Type.NONE;
+    private static long value = 0;
+
+    public static void none() {
+        type = Type.NONE;
+    }
+
+    public static void offset(long time) {
+        type = Type.OFFSET;
+        value = time;
+    }
+
+    public static void lock(long time) {
+        type = Type.LOCK;
+        value = time;
+    }
+
+    public static long getModifiedTime(long timeOfDay) {
+        return switch (type) {
+            case NONE -> timeOfDay;
+            case LOCK -> value;
+            case OFFSET -> timeOfDay < 0 ? timeOfDay - value : timeOfDay + value;
+            default -> throw new IllegalStateException("Not implemented for type " + type);
+        };
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/features/ClientTimeModifier.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/ClientTimeModifier.java
@@ -1,9 +1,23 @@
 package net.earthcomputer.clientcommands.features;
 
+import java.util.function.Function;
+
 public class ClientTimeModifier {
 
-    public static enum Type {
-        NONE, OFFSET, LOCK;
+    public enum Type {
+        NONE(time -> time),
+        OFFSET(time -> time + value),
+        LOCK(time -> value);
+
+        private final Function<Long, Long> timeMappingFunction;
+
+        Type(Function<Long, Long> timeMappingFunction) {
+            this.timeMappingFunction = timeMappingFunction;
+        }
+
+        public long getModifiedTime(long timeOfDay) {
+            return timeMappingFunction.apply(timeOfDay);
+        }
     }
 
     private static Type type = Type.NONE;
@@ -24,11 +38,6 @@ public class ClientTimeModifier {
     }
 
     public static long getModifiedTime(long timeOfDay) {
-        return switch (type) {
-            case NONE -> timeOfDay;
-            case LOCK -> value;
-            case OFFSET -> timeOfDay < 0 ? timeOfDay - value : timeOfDay + value;
-            default -> throw new IllegalStateException("Not implemented for type " + type);
-        };
+        return type.getModifiedTime(timeOfDay);
     }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientWorldProperties.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientWorldProperties.java
@@ -1,0 +1,20 @@
+package net.earthcomputer.clientcommands.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.earthcomputer.clientcommands.features.ClientTimeModifier;
+import net.minecraft.client.world.ClientWorld.Properties;
+
+@Mixin(Properties.class)
+public class MixinClientWorldProperties {
+
+    @Inject(at = @At("TAIL"), method = "getTimeOfDay()J", cancellable = true)
+    public void getTimeOfDay(CallbackInfoReturnable<Long> info) {
+        var timeOfDay = info.getReturnValue();
+        long modifiedTimeOfDay = ClientTimeModifier.getModifiedTime(timeOfDay);
+        info.setReturnValue(modifiedTimeOfDay);
+    }
+}

--- a/src/main/resources/mixins.clientcommands.json
+++ b/src/main/resources/mixins.clientcommands.json
@@ -33,6 +33,7 @@
     "MixinClientPlayerInteractionManager",
     "MixinClientPlayNetworkHandler",
     "MixinClientWorld",
+    "MixinClientWorldProperties",
     "MixinCloseHandledScreenPacket",
     "MixinCraftingTableContainer",
     "MixinCreeperMooshroomSheepAndSnowGolemEntity",


### PR DESCRIPTION
This PR adds a `/ctime set` command allowing to change the clients daytime as discussed in the earthcomputer discord earlier. This is client side only and works in single and multiplayer.

**Command usage**
`/ctime set <day/night/noon/midnight>` to lock the time clientside
`/ctime reset` to unlock and reset to the servers time