### PR TITLE
Add functions and startup commands

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -75,6 +75,8 @@ public class ClientCommands implements ClientModInitializer {
         SnakeCommand.register(dispatcher);
         CTitleCommand.register(dispatcher);
         TooltipCommand.register(dispatcher, registryAccess);
+        CFunctionCommand.register(dispatcher);
+        StartupCommand.register(dispatcher);
 
         CrackRNGCommand.register(dispatcher);
     }

--- a/src/main/java/net/earthcomputer/clientcommands/TempRules.java
+++ b/src/main/java/net/earthcomputer/clientcommands/TempRules.java
@@ -104,6 +104,9 @@ public class TempRules {
     @Rule
     public static boolean infiniteTools = false;
 
+    @Rule
+    public static int commandExecutionLimit = 65536;
+
     public static String asString(Object value) {
         if (value instanceof StringIdentifiable) {
             return ((StringIdentifiable) value).asString();

--- a/src/main/java/net/earthcomputer/clientcommands/command/CFunctionCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/CFunctionCommand.java
@@ -1,0 +1,25 @@
+package net.earthcomputer.clientcommands.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.earthcomputer.clientcommands.features.ClientCommandFunctions;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.command.CommandSource;
+import net.minecraft.text.Text;
+
+import static com.mojang.brigadier.arguments.StringArgumentType.*;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.*;
+
+public class CFunctionCommand {
+    public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
+        dispatcher.register(literal("cfunction")
+            .then(argument("function", greedyString())
+                .suggests((context, builder) -> CommandSource.suggestMatching(ClientCommandFunctions.allFunctions(), builder))
+                .executes(ctx -> run(ctx.getSource(), getString(ctx, "function")))));
+    }
+
+    private static int run(FabricClientCommandSource source, String function) throws CommandSyntaxException {
+        return ClientCommandFunctions.executeFunction(ClientCommandManager.getActiveDispatcher(), source, function, result -> source.sendFeedback(Text.translatable("commands.cfunction.success", result, function)));
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/command/StartupCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/StartupCommand.java
@@ -1,0 +1,91 @@
+package net.earthcomputer.clientcommands.command;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.logging.LogUtils;
+import net.earthcomputer.clientcommands.features.ClientCommandFunctions;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.util.Util;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static com.mojang.brigadier.arguments.StringArgumentType.*;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.*;
+
+public class StartupCommand {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private static final SimpleCommandExceptionType COULD_NOT_CREATE_FILE_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cstartup.couldNotCreateFile"));
+    private static final SimpleCommandExceptionType COULD_NOT_EDIT_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cstartup.couldNotEdit"));
+
+    public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
+        dispatcher.register(literal("cstartup")
+            .then(literal("local")
+                .then(literal("add")
+                    .then(argument("command", greedyString())
+                        .executes(ctx -> addStartupCommand(ctx.getSource(), false, getString(ctx, "command")))))
+                .then(literal("edit")
+                    .executes(ctx -> editStartupCommand(false))))
+            .then(literal("global")
+                .then(literal("add")
+                    .then(argument("command", greedyString())
+                        .executes(ctx -> addStartupCommand(ctx.getSource(), true, getString(ctx, "command")))))
+                .then(literal("edit")
+                    .executes(ctx -> editStartupCommand(true)))));
+    }
+
+    private static int addStartupCommand(FabricClientCommandSource source, boolean global, String command) throws CommandSyntaxException {
+        ensureStartupFileExists(global);
+
+        Path file = global ? ClientCommandFunctions.getGlobalStartupFunction() : ClientCommandFunctions.getLocalStartupFunction();
+        if (file == null) {
+            throw COULD_NOT_CREATE_FILE_EXCEPTION.create();
+        }
+
+        try {
+            Files.writeString(file, command + System.lineSeparator(), StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            LOGGER.error("Failed to append command to startup file", e);
+            throw COULD_NOT_EDIT_EXCEPTION.create();
+        }
+
+        source.sendFeedback(Text.translatable("commands.cstartup.add.success"));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int editStartupCommand(boolean global) throws CommandSyntaxException {
+        ensureStartupFileExists(global);
+
+        Path file = global ? ClientCommandFunctions.getGlobalStartupFunction() : ClientCommandFunctions.getLocalStartupFunction();
+        if (file == null) {
+            throw COULD_NOT_CREATE_FILE_EXCEPTION.create();
+        }
+        Util.getOperatingSystem().open(file.toFile());
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static void ensureStartupFileExists(boolean global) throws CommandSyntaxException {
+        boolean result = true;
+        try {
+            if (global) {
+                ClientCommandFunctions.ensureGlobalStartupFunctionExists();
+            } else {
+                result = ClientCommandFunctions.ensureLocalStartupFunctionExists();
+            }
+        } catch (IOException e) {
+            LOGGER.error("Unable to create startup command file", e);
+            result = false;
+        }
+        if (!result) {
+            throw COULD_NOT_CREATE_FILE_EXCEPTION.create();
+        }
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/command/VarCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/VarCommand.java
@@ -151,4 +151,8 @@ public class VarCommand {
         matcher.appendTail(builder);
         return builder.toString();
     }
+
+    public static boolean containsVars(String command) {
+        return VARIABLE_PATTERN.matcher(command).find();
+    }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
@@ -119,7 +119,7 @@ public class ClientCommandFunctions {
             assert networkHandler != null : "Network handler should not be null while calling ClientCommandFunctions.runStartup()";
             var source = (FabricClientCommandSource) networkHandler.getCommandSource();
             int result = executeFunction(dispatcher, source, startupFunction, res -> {});
-            LOGGER.info("Run {} commands from startup function {}", result, startupFunction);
+            LOGGER.info("Ran {} commands from startup function {}", result, startupFunction);
         } catch (CommandSyntaxException e) {
             LOGGER.error("Error running startup function {}: {}", startupFunction, e.getMessage());
         }

--- a/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
@@ -192,7 +192,7 @@ public class ClientCommandFunctions {
                 if (function.contains(File.separator)) {
                     return null;
                 }
-                function = function.replace(File.separator, "/");
+                function = function.replace("/", File.separator);
             }
             Path path;
             try {

--- a/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
@@ -1,0 +1,232 @@
+package net.earthcomputer.clientcommands.features;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.logging.LogUtils;
+import net.earthcomputer.clientcommands.TempRules;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.integrated.IntegratedServer;
+import net.minecraft.text.Text;
+import net.minecraft.util.FileNameUtil;
+import net.minecraft.util.WorldSavePath;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.IntConsumer;
+import java.util.stream.Stream;
+
+public class ClientCommandFunctions {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private static final Path FUNCTION_DIR = FabricLoader.getInstance().getConfigDir().resolve("clientcommands").resolve("functions");
+
+    private static final DynamicCommandExceptionType NO_SUCH_FUNCTION_EXCEPTION = new DynamicCommandExceptionType(id -> Text.translatable("arguments.function.unknown", id));
+    private static final DynamicCommandExceptionType COMMAND_LIMIT_REACHED_EXCEPTION = new DynamicCommandExceptionType(limit -> Text.translatable("commands.cfunction.limitReached", limit));
+
+    @Nullable
+    public static Path getLocalStartupFunction() {
+        return CommandFunction.getPath(getLocalStartupFunctionStr());
+    }
+
+    private static String getLocalStartupFunctionStr() {
+        MinecraftClient mc = MinecraftClient.getInstance();
+        ServerInfo mpServer = mc.getCurrentServerEntry();
+        String startupFunction;
+        if (mpServer != null) {
+            startupFunction = "startup_multiplayer_" + mpServer.address.replace(':', '_');
+        } else {
+            IntegratedServer server = mc.getServer();
+            if (server != null) {
+                startupFunction = "startup_singleplayer_" + server.getSavePath(WorldSavePath.ROOT).normalize().getFileName();
+            } else {
+                startupFunction = "startup";
+            }
+        }
+        return startupFunction;
+    }
+
+    public static boolean ensureLocalStartupFunctionExists() throws IOException {
+        Path file = getLocalStartupFunction();
+        if (file == null) {
+            return false;
+        }
+        if (Files.exists(file)) {
+            return true;
+        }
+
+        ensureGlobalStartupFunctionExists();
+
+        Files.createDirectories(file.getParent());
+        try (BufferedWriter writer = Files.newBufferedWriter(file)) {
+            writer.append("# This file contains commands to be run when joining this world/server.");
+            writer.newLine();
+            writer.newLine();
+            writer.append("# Run the default startup commands.");
+            writer.newLine();
+            writer.append("cfunction startup");
+            writer.newLine();
+        }
+        return true;
+    }
+
+    public static Path getGlobalStartupFunction() {
+        return FUNCTION_DIR.resolve("startup.mcfunction");
+    }
+
+    public static void ensureGlobalStartupFunctionExists() throws IOException {
+        Path file = getGlobalStartupFunction();
+        if (Files.exists(file)) {
+            return;
+        }
+
+        Files.createDirectories(file.getParent());
+        try (BufferedWriter writer = Files.newBufferedWriter(file)) {
+            writer.append("# This file contains commands to be run when joining any world/server.");
+            writer.newLine();
+        }
+    }
+
+    public static void runStartup() {
+        String startupFunction = getLocalStartupFunctionStr();
+        Path path = CommandFunction.getPath(startupFunction);
+        if (path == null || !Files.exists(path)) {
+            startupFunction = "startup";
+            path = CommandFunction.getPath(startupFunction);
+            if (path == null || !Files.exists(path)) {
+                return;
+            }
+        }
+
+        LOGGER.info("Running startup function {}", startupFunction);
+
+        try {
+            var dispatcher = ClientCommandManager.getActiveDispatcher();
+            var networkHandler = MinecraftClient.getInstance().getNetworkHandler();
+            assert networkHandler != null : "Network handler should not be null while calling ClientCommandFunctions.runStartup()";
+            var source = (FabricClientCommandSource) networkHandler.getCommandSource();
+            int result = executeFunction(dispatcher, source, startupFunction, res -> {});
+            LOGGER.info("Run {} commands from startup function {}", result, startupFunction);
+        } catch (CommandSyntaxException e) {
+            LOGGER.error("Error running startup function {}: {}", startupFunction, e.getMessage());
+        }
+    }
+
+    public static List<String> allFunctions() {
+        try (Stream<Path> paths = Files.walk(FUNCTION_DIR)) {
+            return paths.filter(path -> !Files.isDirectory(path) && path.getFileName().toString().endsWith(".mcfunction")).map(path -> {
+                String name = FUNCTION_DIR.relativize(path).toString();
+                return name.substring(0, name.length() - ".mcfunction".length());
+            }).toList();
+        } catch (IOException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    @Nullable
+    private static ExecutionContext currentContext = null;
+
+    public static int executeFunction(CommandDispatcher<FabricClientCommandSource> dispatcher, FabricClientCommandSource source, String function, IntConsumer successMessageSender) throws CommandSyntaxException {
+        if (currentContext != null) {
+            CommandFunction func = currentContext.functions.get(function);
+            if (func == null) {
+                func = CommandFunction.load(currentContext.dispatcher, currentContext.source, function);
+                currentContext.functions.put(function, func);
+            }
+            for (int i = func.entries.length - 1; i >= 0; i--) {
+                currentContext.entries.addFirst(func.entries[i]);
+            }
+            return Command.SINGLE_SUCCESS;
+        }
+
+        CommandFunction func = CommandFunction.load(dispatcher, source, function);
+        Map<String, CommandFunction> functions = new HashMap<>();
+        functions.put(function, func);
+
+        Deque<Entry> entries = new ArrayDeque<>();
+        Collections.addAll(entries, func.entries);
+
+        currentContext = new ExecutionContext(dispatcher, source, entries, functions);
+        try {
+            int count = 0;
+            while (!entries.isEmpty()) {
+                if (count++ >= TempRules.commandExecutionLimit) {
+                    throw COMMAND_LIMIT_REACHED_EXCEPTION.create(TempRules.commandExecutionLimit);
+                }
+                dispatcher.execute(entries.remove().command);
+            }
+            successMessageSender.accept(count);
+            return count;
+        } finally {
+            currentContext = null;
+        }
+    }
+
+    private record ExecutionContext(
+        CommandDispatcher<FabricClientCommandSource> dispatcher,
+        FabricClientCommandSource source,
+        Deque<Entry> entries,
+        Map<String, CommandFunction> functions
+    ) {
+    }
+
+    private record CommandFunction(Entry[] entries) {
+        @Nullable
+        static Path getPath(String function) {
+            Path path;
+            try {
+                path = FUNCTION_DIR.resolve(function + ".mcfunction");
+            } catch (InvalidPathException e) {
+                return null;
+            }
+            if (!FileNameUtil.isNormal(path) || !FileNameUtil.isAllowedName(path)) {
+                return null;
+            }
+            return path;
+        }
+
+        static CommandFunction load(CommandDispatcher<FabricClientCommandSource> dispatcher, FabricClientCommandSource source, String function) throws CommandSyntaxException {
+            Path path = getPath(function);
+            if (path == null || !Files.exists(path)) {
+                throw NO_SUCH_FUNCTION_EXCEPTION.create(function);
+            }
+
+            List<Entry> entries = new ArrayList<>();
+            try (Stream<String> lines = Files.lines(path)) {
+                for (String line : (Iterable<String>) lines::iterator) {
+                    line = line.trim();
+                    if (line.isEmpty() || line.startsWith("#")) {
+                        continue;
+                    }
+                    var command = dispatcher.parse(line, source);
+                    if (command.getReader().canRead()) {
+                        //noinspection ConstantConditions
+                        throw CommandManager.getException(command);
+                    }
+                    entries.add(new Entry(command));
+                }
+            } catch (IOException e) {
+                LOGGER.error("Failed to read function file {}", path, e);
+                throw NO_SUCH_FUNCTION_EXCEPTION.create(function);
+            }
+
+            return new CommandFunction(entries.toArray(new Entry[0]));
+        }
+    }
+
+    private record Entry(ParseResults<FabricClientCommandSource> command) {
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -131,7 +132,7 @@ public class ClientCommandFunctions {
         try (Stream<Path> paths = Files.walk(FUNCTION_DIR)) {
             return paths.filter(path -> !Files.isDirectory(path) && path.getFileName().toString().endsWith(".mcfunction")).map(path -> {
                 String name = FUNCTION_DIR.relativize(path).toString();
-                return name.substring(0, name.length() - ".mcfunction".length());
+                return name.substring(0, name.length() - ".mcfunction".length()).replace(File.separator, "/");
             }).toList();
         } catch (IOException e) {
             return Collections.emptyList();
@@ -187,6 +188,12 @@ public class ClientCommandFunctions {
     private record CommandFunction(ImmutableList<Entry> entries) {
         @Nullable
         static Path getPath(String function) {
+            if (!"/".equals(File.separator)) {
+                if (function.contains(File.separator)) {
+                    return null;
+                }
+                function = function.replace(File.separator, "/");
+            }
             Path path;
             try {
                 path = FUNCTION_DIR.resolve(function + ".mcfunction");

--- a/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
@@ -1,5 +1,6 @@
 package net.earthcomputer.clientcommands.features;
 
+import com.google.common.collect.ImmutableList;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.ParseResults;
@@ -147,8 +148,8 @@ public class ClientCommandFunctions {
                 func = CommandFunction.load(currentContext.dispatcher, currentContext.source, function);
                 currentContext.functions.put(function, func);
             }
-            for (int i = func.entries.length - 1; i >= 0; i--) {
-                currentContext.entries.addFirst(func.entries[i]);
+            for (int i = func.entries.size() - 1; i >= 0; i--) {
+                currentContext.entries.addFirst(func.entries.get(i));
             }
             return Command.SINGLE_SUCCESS;
         }
@@ -157,8 +158,7 @@ public class ClientCommandFunctions {
         Map<String, CommandFunction> functions = new HashMap<>();
         functions.put(function, func);
 
-        Deque<Entry> entries = new ArrayDeque<>();
-        Collections.addAll(entries, func.entries);
+        Deque<Entry> entries = new ArrayDeque<>(func.entries);
 
         currentContext = new ExecutionContext(dispatcher, source, entries, functions);
         try {
@@ -184,7 +184,7 @@ public class ClientCommandFunctions {
     ) {
     }
 
-    private record CommandFunction(Entry[] entries) {
+    private record CommandFunction(ImmutableList<Entry> entries) {
         @Nullable
         static Path getPath(String function) {
             Path path;
@@ -205,7 +205,7 @@ public class ClientCommandFunctions {
                 throw NO_SUCH_FUNCTION_EXCEPTION.create(function);
             }
 
-            List<Entry> entries = new ArrayList<>();
+            var entries = ImmutableList.<Entry>builder();
             try (Stream<String> lines = Files.lines(path)) {
                 for (String line : (Iterable<String>) lines::iterator) {
                     line = line.trim();
@@ -228,7 +228,7 @@ public class ClientCommandFunctions {
                 throw NO_SUCH_FUNCTION_EXCEPTION.create(function);
             }
 
-            return new CommandFunction(entries.toArray(new Entry[0]));
+            return new CommandFunction(entries.build());
         }
     }
 

--- a/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/ClientCommandFunctions.java
@@ -7,11 +7,11 @@ import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.logging.LogUtils;
+import net.earthcomputer.clientcommands.ClientCommands;
 import net.earthcomputer.clientcommands.TempRules;
 import net.earthcomputer.clientcommands.command.VarCommand;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ServerInfo;
 import net.minecraft.server.command.CommandManager;
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 public class ClientCommandFunctions {
     private static final Logger LOGGER = LogUtils.getLogger();
 
-    private static final Path FUNCTION_DIR = FabricLoader.getInstance().getConfigDir().resolve("clientcommands").resolve("functions");
+    private static final Path FUNCTION_DIR = ClientCommands.configDir.resolve("functions");
 
     private static final DynamicCommandExceptionType NO_SUCH_FUNCTION_EXCEPTION = new DynamicCommandExceptionType(id -> Text.translatable("arguments.function.unknown", id));
     private static final DynamicCommandExceptionType COMMAND_LIMIT_REACHED_EXCEPTION = new DynamicCommandExceptionType(limit -> Text.translatable("commands.cfunction.limitReached", limit));

--- a/src/main/java/net/earthcomputer/clientcommands/features/Relogger.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/Relogger.java
@@ -83,10 +83,12 @@ public class Relogger {
         relogSuccessTasks.clear();
     }
 
-    public static void onRelogSuccess() {
+    public static boolean onRelogSuccess() {
+        boolean result = !relogSuccessTasks.isEmpty();
         for (Runnable task : relogSuccessTasks) {
             task.run();
         }
         relogSuccessTasks.clear();
+        return result;
     }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientPlayNetworkHandler.java
@@ -1,15 +1,12 @@
 package net.earthcomputer.clientcommands.mixin;
 
-import com.mojang.brigadier.CommandDispatcher;
 import net.cortex.clientAddon.cracker.SeedCracker;
 import net.earthcomputer.clientcommands.ServerBrandManager;
 import net.earthcomputer.clientcommands.TempRules;
 import net.earthcomputer.clientcommands.features.FishingCracker;
-import net.earthcomputer.clientcommands.features.Relogger;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.command.CommandSource;
 import net.minecraft.entity.EntityType;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket;
@@ -24,16 +21,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPlayNetworkHandler.class)
 public class MixinClientPlayNetworkHandler {
-
-    @Shadow
-    private CommandDispatcher<CommandSource> commandDispatcher;
-
     @Shadow @Final private MinecraftClient client;
-
-    @Inject(method = "onGameJoin", at = @At("RETURN"))
-    private void postGameJoin(CallbackInfo ci) {
-        Relogger.onRelogSuccess();
-    }
 
     @Inject(method = "onEntitySpawn", at = @At("TAIL"))
     public void onOnEntitySpawn(EntitySpawnS2CPacket packet, CallbackInfo ci) {

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientPlayNetworkHandlerHighPriority.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientPlayNetworkHandlerHighPriority.java
@@ -1,0 +1,19 @@
+package net.earthcomputer.clientcommands.mixin;
+
+import net.earthcomputer.clientcommands.features.ClientCommandFunctions;
+import net.earthcomputer.clientcommands.features.Relogger;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = ClientPlayNetworkHandler.class, priority = 2000)
+public class MixinClientPlayNetworkHandlerHighPriority {
+    @Inject(method = "onGameJoin", at = @At("RETURN"))
+    private void postGameJoin(CallbackInfo ci) {
+        if (!Relogger.onRelogSuccess()) {
+            ClientCommandFunctions.runStartup();
+        }
+    }
+}

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -90,7 +90,7 @@
   "commands.cfov.success": "Set FOV to %f",
 
   "commands.cfunction.limitReached": "Command limit (%d) reached",
-  "commands.cfunction.success": "Run %d commands from function %s",
+  "commands.cfunction.success": "Ran %d commands from function %s",
 
   "commands.cgamma.success": "Set gamma to %f",
 

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -89,6 +89,9 @@
 
   "commands.cfov.success": "Set FOV to %f",
 
+  "commands.cfunction.limitReached": "Command limit (%d) reached",
+  "commands.cfunction.success": "Run %d commands from function %s",
+
   "commands.cgamma.success": "Set gamma to %f",
 
   "commands.cghostblock.fill.success": "%d ghost blocks filled",
@@ -145,6 +148,10 @@
   "commands.crelog.failed": "Failed to relog",
 
   "commands.crender.entities.success": "Entity rendering rules have been updated",
+
+  "commands.cstartup.add.success": "Added command to startup file",
+  "commands.cstartup.couldNotCreateFile": "Couldn't create startup file",
+  "commands.cstartup.couldNotEdit": "Couldn't edit startup file",
 
   "commands.cstopsound.success.sourceless.any": "Stopped all sounds for self",
   "commands.cstopsound.success.sourceless.sound": "Stopped sound '%s' for self",

--- a/src/main/resources/mixins.clientcommands.json
+++ b/src/main/resources/mixins.clientcommands.json
@@ -5,9 +5,9 @@
   "mixins": [
     "AlternativeLootConditionAccessor",
     "AndConditionAccessor",
+    "ChatInputSuggestorAccessor",
     "CheckedRandomAccessor",
     "CombinedEntryAccessor",
-    "ChatInputSuggestorAccessor",
     "CreativeInventoryScreenAccessor",
     "EntityPredicateAccessor",
     "EntityPropertiesLootConditionAccessor",
@@ -82,5 +82,8 @@
   },
   "overwrites": {
     "requireAnnotations": true
-  }
+  },
+  "client": [
+    "MixinClientPlayNetworkHandlerHighPriority"
+  ]
 }

--- a/src/main/resources/mixins.clientcommands.json
+++ b/src/main/resources/mixins.clientcommands.json
@@ -33,6 +33,7 @@
     "MixinClientPlayerEntity",
     "MixinClientPlayerInteractionManager",
     "MixinClientPlayNetworkHandler",
+    "MixinClientPlayNetworkHandlerHighPriority",
     "MixinClientWorld",
     "MixinClientWorldProperties",
     "MixinCloseHandledScreenPacket",
@@ -83,8 +84,5 @@
   },
   "overwrites": {
     "requireAnnotations": true
-  },
-  "client": [
-    "MixinClientPlayNetworkHandlerHighPriority"
-  ]
+  }
 }


### PR DESCRIPTION
Adds two commands: `/cfunction` and `/cstartup`.

A specially named function (based on the server ip / world name) is automatically run on "startup" (server/world join) if present, which by default calls a common startup function. The `/cstartup` command is just a convenience for creating and editing these special functions.