### PR TITLE
Allow /cping to work for all players

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/command/PingCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/PingCommand.java
@@ -1,41 +1,80 @@
 package net.earthcomputer.clientcommands.command;
 
+import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.text.Text;
 
+import java.util.Collection;
+
+import static dev.xpple.clientarguments.arguments.CGameProfileArgumentType.*;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.*;
 
 public class PingCommand {
+
+    private static final SimpleCommandExceptionType PLAYER_IN_SINGLEPLAYER_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cping.singleplayer"));
+    private static final SimpleCommandExceptionType PLAYER_NOT_FOUND_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cping.playerNotFound"));
+
     public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
         dispatcher.register(literal("cping")
-            .executes(ctx -> printPing(ctx.getSource())));
+            .executes(ctx -> printPing(ctx.getSource()))
+            .then(argument("player", gameProfile())
+                .executes(ctx -> printPing(ctx.getSource(), getCProfileArgument(ctx, "player"))))
+        );
     }
 
-    private static int printPing(FabricClientCommandSource source) {
-        int ping = getLocalPing();
-
-        if (ping == -1 || source.getClient().isInSingleplayer()) {
-            source.sendFeedback(Text.translatable("commands.cping.local"));
-        } else {
-            source.sendFeedback(Text.translatable("commands.cping.multiplayer", ping));
+    private static int printPing(FabricClientCommandSource source) throws CommandSyntaxException {
+        if (source.getClient().isInSingleplayer()) {
+            throw PLAYER_IN_SINGLEPLAYER_EXCEPTION.create();
         }
 
+        int ping = getLocalPing();
+        if (ping == -1) {
+            throw PLAYER_IN_SINGLEPLAYER_EXCEPTION.create();
+        }
+
+        source.sendFeedback(Text.translatable("commands.cping.success", ping));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int printPing(FabricClientCommandSource source, Collection<GameProfile> profiles) throws CommandSyntaxException {
+        if (source.getClient().isInSingleplayer()) {
+            throw PLAYER_IN_SINGLEPLAYER_EXCEPTION.create();
+        }
+
+        if (profiles.size() != 1) {
+            throw PLAYER_NOT_FOUND_EXCEPTION.create();
+        }
+        GameProfile profile = profiles.iterator().next();
+
+        ClientPlayNetworkHandler networkHandler = source.getClient().getNetworkHandler();
+        assert networkHandler != null;
+        PlayerListEntry player = networkHandler.getPlayerListEntry(profile.getId());
+        if (player == null) {
+            throw PLAYER_NOT_FOUND_EXCEPTION.create();
+        }
+
+        int ping = player.getLatency();
+        source.sendFeedback(Text.translatable("commands.cping.success.other", profile.getName(), ping));
         return Command.SINGLE_SUCCESS;
     }
 
     public static int getLocalPing() {
         ClientPlayNetworkHandler networkHandler = MinecraftClient.getInstance().getNetworkHandler();
-        if (networkHandler == null)
+        if (networkHandler == null) {
             return -1;
+        }
 
         PlayerListEntry localPlayer = networkHandler.getPlayerListEntry(networkHandler.getProfile().getId());
-        if (localPlayer == null)
+        if (localPlayer == null) {
             return -1;
+        }
 
         return localPlayer.getLatency();
     }

--- a/src/main/java/net/earthcomputer/clientcommands/command/PingCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/PingCommand.java
@@ -20,6 +20,8 @@ public class PingCommand {
 
     private static final SimpleCommandExceptionType PLAYER_IN_SINGLEPLAYER_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cping.singleplayer"));
     private static final SimpleCommandExceptionType PLAYER_NOT_FOUND_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cping.playerNotFound"));
+    private static final SimpleCommandExceptionType TOO_MANY_PLAYERS_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cping.tooManyPlayers"));
+
 
     public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
         dispatcher.register(literal("cping")
@@ -48,8 +50,11 @@ public class PingCommand {
             throw PLAYER_IN_SINGLEPLAYER_EXCEPTION.create();
         }
 
-        if (profiles.size() != 1) {
+        if (profiles.isEmpty()) {
             throw PLAYER_NOT_FOUND_EXCEPTION.create();
+        }
+        if (profiles.size() > 1) {
+            throw TOO_MANY_PLAYERS_EXCEPTION.create();
         }
         GameProfile profile = profiles.iterator().next();
 

--- a/src/main/java/net/earthcomputer/clientcommands/command/PingCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/PingCommand.java
@@ -22,7 +22,6 @@ public class PingCommand {
     private static final SimpleCommandExceptionType PLAYER_NOT_FOUND_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cping.playerNotFound"));
     private static final SimpleCommandExceptionType TOO_MANY_PLAYERS_EXCEPTION = new SimpleCommandExceptionType(Text.translatable("commands.cping.tooManyPlayers"));
 
-
     public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
         dispatcher.register(literal("cping")
             .executes(ctx -> printPing(ctx.getSource()))

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -142,8 +142,10 @@
 
   "commands.cplaysound.success": "Played sound %s to self",
 
-  "commands.cping.local": "You are in a singleplayer world (╯°□°）╯︵ ┻━┻",
-  "commands.cping.multiplayer": "Your average ping is %dms",
+  "commands.cping.success": "Your average ping is %dms",
+  "commands.cping.success.other": "The average ping of %s is %dms",
+  "commands.cping.singleplayer": "You are in a singleplayer world (╯°□°）╯︵ ┻━┻",
+  "commands.cping.playerNotFound": "Player not found",
 
   "commands.crelog.failed": "Failed to relog",
 

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -146,6 +146,7 @@
   "commands.cping.success.other": "The average ping of %s is %dms",
   "commands.cping.singleplayer": "You are in a singleplayer world (╯°□°）╯︵ ┻━┻",
   "commands.cping.playerNotFound": "Player not found",
+  "commands.cping.tooManyPlayers": "Your query can match at most 1 player",
 
   "commands.crelog.failed": "Failed to relog",
 

--- a/src/main/resources/assets/clientcommands/lang/id_id.json
+++ b/src/main/resources/assets/clientcommands/lang/id_id.json
@@ -138,8 +138,8 @@
 
   "commands.cplaysound.success": "Memainkan suara %s ke diri sendiri",
 
-  "commands.cping.local": "Kamu berada di dunia singleplayer (╯°□°）╯︵ ┻━┻",
-  "commands.cping.multiplayer": "Ping rata ratamu adalah %dms",
+  "commands.cping.singleplayer": "Kamu berada di dunia singleplayer (╯°□°）╯︵ ┻━┻",
+  "commands.cping.success": "Ping rata ratamu adalah %dms",
 
   "commands.crelog.failed": "Gagal relog",
 

--- a/src/main/resources/assets/clientcommands/lang/ru_ru.json
+++ b/src/main/resources/assets/clientcommands/lang/ru_ru.json
@@ -138,8 +138,8 @@
 
   "commands.cplaysound.success": "Проиграл звук %s самому себе",
 
-  "commands.cping.local": "Вы находитесь в одиночном мире (╯°□°）╯︵ ┻━┻",
-  "commands.cping.multiplayer": "Ваш средний пинг %dms",
+  "commands.cping.singleplayer": "Вы находитесь в одиночном мире (╯°□°）╯︵ ┻━┻",
+  "commands.cping.success": "Ваш средний пинг %dms",
 
   "commands.crelog.failed": "Не удалось повторно войти",
 

--- a/src/main/resources/assets/clientcommands/lang/zh_cn.json
+++ b/src/main/resources/assets/clientcommands/lang/zh_cn.json
@@ -139,8 +139,8 @@
 
   "commands.cplaysound.success": "成功播放音效 %s 给自己",
 
-  "commands.cping.local": "你在单人游戏世界(╯°□°）╯︵ ┻━┻",
-  "commands.cping.multiplayer": "你的平均ping是%d毫秒",
+  "commands.cping.singleplayer": "你在单人游戏世界(╯°□°）╯︵ ┻━┻",
+  "commands.cping.success": "你的平均ping是%d毫秒",
   
   "commands.crelog.failed": "未能重新登录",
 


### PR DESCRIPTION
Closes #404. I couldn't really do any fancy method overloading stuff because the `getLocalPing` method had to stay for the fishing cracker.