### PR TITLE
Actions fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          distribution: 'zulu'
+          java-version: '17'
       - uses: actions/cache@v3
         with:
           path: |
@@ -21,7 +22,7 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
       - run: ./gradlew build -Pmod_version="$(git describe --always --tags | cut -c2-)" --stacktrace --no-daemon
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: clientcommands-snapshot
           path: build/libs/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Check Build
+name: Check Pull Request
 on:
   pull_request:
     branches: ['*']

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,11 +7,12 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          distribution: 'zulu'
+          java-version: '17'
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
I've updated `actions/setup-java` from `v1` to `v3`, `actions/checkout` from `v2` to `v3`, and `actions/upload-artifact` from `v2` to `v3`, which will fix the following warning messages:
![image](https://user-images.githubusercontent.com/66096725/208541701-555399a6-8428-408c-9964-78b375913db0.png)

I've also renamed the PR action to be more descriptive ("Check Build" -> "Check Pull Request").

I set the Java distribution to `Azul Zulu OpenJDK`, as that was the old version of the action used. If you prefer a specific one to be used, let me know.