### PR TITLE
Allow required custom resource packs to be bypassed

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/Configs.java
+++ b/src/main/java/net/earthcomputer/clientcommands/Configs.java
@@ -109,4 +109,13 @@ public class Configs {
 
     @Config
     public static boolean acceptC2CPackets = false;
+
+    public enum ResourcePackBypassPolicy {
+        VANILLA,
+        BYPASS_FORCED,
+        BYPASS_ALL;
+    }
+
+    @Config
+    public static ResourcePackBypassPolicy resourcePackBypassPolicy = ResourcePackBypassPolicy.VANILLA;
 }

--- a/src/main/java/net/earthcomputer/clientcommands/features/BypassRequiredResourcePackScreen.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/BypassRequiredResourcePackScreen.java
@@ -1,0 +1,23 @@
+package net.earthcomputer.clientcommands.features;
+
+import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+
+public class BypassRequiredResourcePackScreen extends ConfirmScreen {
+
+    private final Runnable bypassCallback;
+
+    public BypassRequiredResourcePackScreen(BooleanConsumer callback, Runnable bypassCallback, Text message) {
+        super(callback, Text.translatable("multiplayer.requiredTexturePrompt.line1"), message, ScreenTexts.PROCEED, Text.translatable("menu.disconnect"));
+        this.bypassCallback = bypassCallback;
+    }
+
+    @Override
+    protected void addButtons(int y) {
+        super.addButtons(y);
+        this.addButton(ButtonWidget.builder(Text.translatable("resourcePackBypass.bypass"), button -> this.bypassCallback.run()).dimensions(this.width / 2 - 155 / 2, y + 30, 150, 20).build());
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/MixinClientPlayNetworkHandler.java
@@ -2,18 +2,26 @@ package net.earthcomputer.clientcommands.mixin;
 
 import com.mojang.brigadier.StringReader;
 import net.cortex.clientAddon.cracker.SeedCracker;
-import net.earthcomputer.clientcommands.ServerBrandManager;
 import net.earthcomputer.clientcommands.Configs;
+import net.earthcomputer.clientcommands.ServerBrandManager;
+import net.earthcomputer.clientcommands.features.BypassRequiredResourcePackScreen;
 import net.earthcomputer.clientcommands.features.FishingCracker;
 import net.earthcomputer.clientcommands.features.PlayerRandCracker;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.client.option.ServerList;
 import net.minecraft.entity.EntityType;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.network.packet.c2s.play.ResourcePackStatusC2SPacket;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket;
 import net.minecraft.network.packet.s2c.play.ExperienceOrbSpawnS2CPacket;
+import net.minecraft.network.packet.s2c.play.ResourcePackSendS2CPacket;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,9 +29,29 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+
 @Mixin(ClientPlayNetworkHandler.class)
-public class MixinClientPlayNetworkHandler {
+public abstract class MixinClientPlayNetworkHandler {
+
     @Shadow @Final private MinecraftClient client;
+
+    @Shadow protected abstract void sendResourcePackStatus(ResourcePackStatusC2SPacket.Status packStatus);
+
+    @Shadow @Final private @Nullable ServerInfo serverInfo;
+
+    @Shadow protected abstract void feedbackAfterDownload(CompletableFuture<?> downloadFuture);
+
+    @Shadow @Final private ClientConnection connection;
+
+    @Shadow private static @Nullable URL resolveUrl(String url) {
+        throw new AssertionError();
+    }
+
+    @Shadow private static Text getServerResourcePackPrompt(Text defaultPrompt, @Nullable Text customPrompt) {
+        throw new AssertionError();
+    }
 
     @Inject(method = "onEntitySpawn", at = @At("TAIL"))
     public void onOnEntitySpawn(EntitySpawnS2CPacket packet, CallbackInfo ci) {
@@ -84,6 +112,54 @@ public class MixinClientPlayNetworkHandler {
     public void onOnCustomPayload(CustomPayloadS2CPacket packet, CallbackInfo ci) {
         if (CustomPayloadS2CPacket.BRAND.equals(packet.getChannel())) {
             ServerBrandManager.setServerBrand(this.client.player.getServerBrand());
+        }
+    }
+
+    @Inject(method = "onResourcePackSend", at = @At("HEAD"), cancellable = true)
+    private void onOnResourcePackSend(ResourcePackSendS2CPacket packet, CallbackInfo ci) {
+        if (this.serverInfo != null && this.serverInfo.getResourcePackPolicy() == ServerInfo.ResourcePackPolicy.ENABLED) {
+            return;
+        }
+        if (this.serverInfo != null && this.serverInfo.getResourcePackPolicy() == ServerInfo.ResourcePackPolicy.DISABLED) {
+            this.sendResourcePackStatus(ResourcePackStatusC2SPacket.Status.ACCEPTED);
+            this.sendResourcePackStatus(ResourcePackStatusC2SPacket.Status.SUCCESSFULLY_LOADED);
+            this.client.inGameHud.getChatHud().addMessage(Text.translatable("resourcePackBypass.bypassed"));
+            ci.cancel();
+            return;
+        }
+        if (this.serverInfo == null || this.serverInfo.getResourcePackPolicy() == ServerInfo.ResourcePackPolicy.PROMPT) {
+            if (Configs.resourcePackBypassPolicy == Configs.ResourcePackBypassPolicy.VANILLA && packet.isRequired()) {
+                this.client.execute(() -> this.client.setScreen(new BypassRequiredResourcePackScreen(proceed -> {
+                    this.client.setScreen(null);
+                    if (proceed) {
+                        if (this.serverInfo != null) {
+                            this.serverInfo.setResourcePackPolicy(ServerInfo.ResourcePackPolicy.ENABLED);
+                        }
+                        this.sendResourcePackStatus(ResourcePackStatusC2SPacket.Status.ACCEPTED);
+                        this.feedbackAfterDownload(this.client.getServerResourcePackProvider().download(resolveUrl(packet.getURL()), packet.getSHA1(), true));
+                    } else {
+                        this.sendResourcePackStatus(ResourcePackStatusC2SPacket.Status.DECLINED);
+                        this.connection.disconnect(Text.translatable("multiplayer.requiredTexturePrompt.disconnect"));
+                    }
+                    if (this.serverInfo != null) {
+                        ServerList.updateServerListEntry(this.serverInfo);
+                    }
+                }, () -> {
+                    this.client.setScreen(null);
+                    Configs.resourcePackBypassPolicy = Configs.ResourcePackBypassPolicy.BYPASS_FORCED;
+                    this.sendResourcePackStatus(ResourcePackStatusC2SPacket.Status.ACCEPTED);
+                    this.sendResourcePackStatus(ResourcePackStatusC2SPacket.Status.SUCCESSFULLY_LOADED);
+                    this.client.inGameHud.getChatHud().addMessage(Text.translatable("resourcePackBypass.bypassed"));
+                }, getServerResourcePackPrompt(Text.translatable("resourcePackBypass.rejectOrBypass"), packet.getPrompt()))));
+                ci.cancel();
+                return;
+            }
+            if (Configs.resourcePackBypassPolicy == Configs.ResourcePackBypassPolicy.BYPASS_FORCED && packet.isRequired() || Configs.resourcePackBypassPolicy == Configs.ResourcePackBypassPolicy.BYPASS_ALL) {
+                this.sendResourcePackStatus(ResourcePackStatusC2SPacket.Status.ACCEPTED);
+                this.sendResourcePackStatus(ResourcePackStatusC2SPacket.Status.SUCCESSFULLY_LOADED);
+                this.client.inGameHud.getChatHud().addMessage(Text.translatable("resourcePackBypass.bypassed"));
+                ci.cancel();
+            }
         }
     }
 }

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -304,5 +304,9 @@
   "ccpacket.sentC2CPacket": "You have sent a C2C packet, but you aren't accepting incoming C2C packets!",
 
   "ccpacket.messageC2CPacket.incoming": "%s -> you: %s",
-  "ccpacket.messageC2CPacket.outgoing": "you -> %s: %s"
+  "ccpacket.messageC2CPacket.outgoing": "you -> %s: %s",
+
+  "resourcePackBypass.rejectOrBypass": "Accept the resource pack, reject the resource pack and disconnect, or bypass it.",
+  "resourcePackBypass.bypass": "Bypass",
+  "resourcePackBypass.bypassed": "You have bypassed the required custom resource pack!"
 }


### PR DESCRIPTION
As the title suggests, the player will be able to bypass the required custom resource pack often imposed by servers. For the newly added config `resourcePackBypassPolicy`, three values are distinguished:

1. `VANILLA` - the client will behave as usual,
2. `BYPASS_FORCED` - the client will automatically bypass _required_ custom resource packs,
3. `BYPASS_ALL` - the client will automatically bypass _all_ custom resource packs.

This config value will only apply when the player has not manually changed the resource pack policy in the server info screen. That is, if the player has set this policy to "disabled", the custom resource pack will always be bypassed. If the player has set this policy to "enabled", the custom resource pack will always be accepted.

If the policy is "prompt" (the default), the config is set to `VANILLA` and the custom resource pack is required, the confirmation screen will also contain a bypass button that when clicked will set the config to `BYPASS_FORCED` and bypass the required custom resource pack. In all other cases the default confirmation screen will be shown.