### PR TITLE
Remove duplicate repo in maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,6 @@ repositories {
 	maven {
 		url = "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1"
 	}
-	maven {
-		url = 'https://maven.seedfinding.com'
-	}
 }
 
 loom {


### PR DESCRIPTION
`https://maven.seedfinding.com/` was in double, so I removed it.

Introduced in commit fb03c4774a24d5f7e6a34a1d49d1c0c5a4ee95bd