### PR TITLE
Updated Fabric libraries and ViaVersion integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.4-SNAPSHOT'
+	id 'fabric-loom' version '1.5-SNAPSHOT'
 	id 'maven-publish'
 	id 'com.modrinth.minotaur' version '2.+'
 	id 'com.github.breadmoirai.github-release' version '2.4.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx2G
 	minecraft_version_list=1.20.3, 1.20.4
 	minecraft_version_list_presentable=1.20.3 - 1.20.4
 	yarn_mappings=1.20.4+build.1
-	loader_version=0.15.0
+	loader_version=0.15.6
 
 # Mod Properties
 	mod_version=2.8.9
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx2G
 
 # Dependencies
 	# also check this on https://fabricmc.net/develop/
-	fabric_version=0.91.1+1.20.4
+	fabric_version=0.95.1+1.20.4
 	clientarguments_version=1.7
 	betterconfig_version=1.2.1
 	seedfinding_core_version=1.192.1


### PR DESCRIPTION
Fixes ViaFabricPlus 3+ integration, older versions of ViaFabricPlus won't start in 1.20.3/4 so we don't need to care about them.