### PR TITLE
use a valid SPDX license identifier

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,7 @@
   "description": "Useful client-side commands",
   "version": "${version}",
   "environment": "client",
-  "license": "LGPL",
+  "license": "LGPL-3.0-or-later",
   "icon": "assets/clientcommands/icon.png",
   "contact": {
     "homepage": "https://earthcomputer.net/",


### PR DESCRIPTION
as per the [fabric.mod.json specification](https://fabricmc.net/wiki/documentation:fabric_mod_json_spec), the `license` field should contain a valid SPDX license identifier