### PR TITLE
modernize build gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ jar {
 	from(configurations.includedLibrary.collect { it.isDirectory() ? it : zipTree(it) }) {
 		include 'com/seedfinding/**'
 	}
+
+	from("LICENSE") {
+		rename { "${it}_${project.base.archivesName.get()}" }
+	}
 }
 
 processResources {
@@ -110,10 +114,6 @@ tasks.register('sourcesJar', Jar) {
 	dependsOn classes
 	archiveClassifier.set("sources")
 	from sourceSets.main.allSource
-}
-
-jar {
-	from "LICENSE"
 }
 
 tasks.register('codeGen', JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -80,9 +80,7 @@ jar {
 		include 'com/seedfinding/**'
 	}
 
-	from("LICENSE") {
-		rename { "${it}_${project.base.archivesName.get()}" }
-	}
+	from("LICENSE")
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,11 @@ plugins {
 	id 'com.github.breadmoirai.github-release' version '2.4.1'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
-
-archivesBaseName = project.archives_base_name
-version = project.mod_version
-group = project.maven_group
+base {
+	archivesName = project.archives_base_name
+	version = project.mod_version
+	group = project.maven_group
+}
 
 sourceSets {
 	codeGen
@@ -96,6 +95,11 @@ processResources {
 	from(sourceSets.main.resources.srcDirs) {
 		exclude "fabric.mod.json"
 	}
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
this pull request accomplishes two goals:
1. remove gradle deprecation warnings
2. rename license file when building to prevent accidentally overwriting other license files in a JiJ scenario