### PR TITLE
Fix recursive alias detection

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/command/AliasCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/AliasCommand.java
@@ -78,7 +78,7 @@ public class AliasCommand {
         if (cmd == null) {
             throw NOT_FOUND_EXCEPTION.create(aliasKey);
         }
-        
+
         if (((IClientSuggestionsProvider_Alias) source).clientcommands_isAliasSeen(aliasKey)) {
             throw RECURSIVE_ALIAS_EXCEPTION.create(aliasKey);
         }

--- a/src/main/java/net/earthcomputer/clientcommands/interfaces/IClientSuggestionsProvider_Alias.java
+++ b/src/main/java/net/earthcomputer/clientcommands/interfaces/IClientSuggestionsProvider_Alias.java
@@ -3,5 +3,7 @@ package net.earthcomputer.clientcommands.interfaces;
 public interface IClientSuggestionsProvider_Alias {
     void clientcommands_addSeenAlias(String alias);
 
+    void clientcommands_removeSeenAlias(String alias);
+
     boolean clientcommands_isAliasSeen(String alias);
 }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/commands/alias/ClientSuggestionProviderMixin.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/commands/alias/ClientSuggestionProviderMixin.java
@@ -19,6 +19,11 @@ public class ClientSuggestionProviderMixin implements IClientSuggestionsProvider
     }
 
     @Override
+    public void clientcommands_removeSeenAlias(String alias) {
+        seenAliases.remove(alias);
+    }
+
+    @Override
     public boolean clientcommands_isAliasSeen(String alias) {
         return seenAliases.contains(alias);
     }


### PR DESCRIPTION
Fixes #645 

When trying to detect whether or not an alias is recursive, it's added to an array of seen aliases. However this array was never cleared meaning after an alias is executed, it cannot be executed again with the error 'Recursive alias "[name of alias]"' appearing in chat despite there being no recursion.

I've confirmed that this issue does not occur on 2.8.18 but occurs after 2.8.19, after the recursion detection was added.

This pull request fixes the issue by removing the alias from the list of seen aliases after the command is completed.