### PR TITLE
Added a way to limit xp used with /cenchant

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/Configs.java
+++ b/src/main/java/net/earthcomputer/clientcommands/Configs.java
@@ -104,15 +104,15 @@ public class Configs {
         Configs.maxEnchantLevels = Math.max(Configs.maxEnchantLevels, Configs.minEnchantLevels);
     }
 
-    @Config(setter = @Config.Setter("setMaxExperienceConsumed"), temporary = true)
-    private static int maxExperienceConsumed = 3;
+    @Config(setter = @Config.Setter("setMaxEnchantSlot"), temporary = true)
+    private static int maxEnchantSlot = 3;
 
-    public static int getMaxExperienceConsumed() {
-        return maxExperienceConsumed;
+    public static int getMaxEnchantSlot() {
+        return maxEnchantSlot;
     }
 
-    public static void setMaxExperienceConsumed(int minEnchantLevels) {
-        Configs.maxExperienceConsumed = Mth.clamp(maxExperienceConsumed, 1, 3);
+    public static void setMaxEnchantSlot(int minEnchantLevels) {
+        Configs.maxEnchantSlot = Mth.clamp(maxEnchantSlot, 1, 3);
     }
 
     @Config(setter = @Config.Setter("setMaxEnchantLevels"), temporary = true)

--- a/src/main/java/net/earthcomputer/clientcommands/Configs.java
+++ b/src/main/java/net/earthcomputer/clientcommands/Configs.java
@@ -104,6 +104,17 @@ public class Configs {
         Configs.maxEnchantLevels = Math.max(Configs.maxEnchantLevels, Configs.minEnchantLevels);
     }
 
+    @Config(setter = @Config.Setter("setMaxExperienceConsumed"), temporary = true)
+    private static int maxExperienceConsumed = 3;
+
+    public static int getMaxExperienceConsumed() {
+        return maxExperienceConsumed;
+    }
+
+    public static void setMaxExperienceConsumed(int minEnchantLevels) {
+        Configs.maxExperienceConsumed = Mth.clamp(maxExperienceConsumed, 1, 3);
+    }
+
     @Config(setter = @Config.Setter("setMaxEnchantLevels"), temporary = true)
     private static int maxEnchantLevels = 30;
     public static int getMaxEnchantLevels() {

--- a/src/main/java/net/earthcomputer/clientcommands/features/EnchantmentCracker.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/EnchantmentCracker.java
@@ -383,7 +383,8 @@ public class EnchantmentCracker {
                             }
                             enchantLevels[slot] = level;
                         }
-                        for (int slot = 0; slot < 3; slot++) {
+                        int maxExperienceConsumed = Configs.getMaxExperienceConsumed();
+                        for (int slot = 0; slot < maxExperienceConsumed; slot++) {
                             List<EnchantmentInstance> enchantments = getEnchantmentList(enchantmentRegistry, rand, xpSeed, stack, slot, enchantLevels[slot], version);
                             if (enchantmentsPredicate.test(enchantments)
                                 && enchantLevels[slot] >= Configs.getMinEnchantLevels()

--- a/src/main/java/net/earthcomputer/clientcommands/features/EnchantmentCracker.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/EnchantmentCracker.java
@@ -383,8 +383,8 @@ public class EnchantmentCracker {
                             }
                             enchantLevels[slot] = level;
                         }
-                        int maxExperienceConsumed = Configs.getMaxExperienceConsumed();
-                        for (int slot = 0; slot < maxExperienceConsumed; slot++) {
+                        int maxEnchantSlot = Configs.getMaxEnchantSlot();
+                        for (int slot = 0; slot < maxEnchantSlot; slot++) {
                             List<EnchantmentInstance> enchantments = getEnchantmentList(enchantmentRegistry, rand, xpSeed, stack, slot, enchantLevels[slot], version);
                             if (enchantmentsPredicate.test(enchantments)
                                 && enchantLevels[slot] >= Configs.getMinEnchantLevels()


### PR DESCRIPTION
This is useful when you want to use as little xp level as possible.


How did I tested this pr:

```log
[23:05:15] [Render thread/INFO]: [CHAT] Player RNG cracked: c1700935c5bb

[23:05:17] [Render thread/INFO]: [CHAT] maxExperienceConsumed has been set to 1.

[23:05:23] [Render thread/INFO]: [CHAT] Starting enchantment manipulation. Cancel
[23:05:23] [Render thread/INFO]: [CHAT] Item throws needed: 8 (about 0.4 seconds)
[23:05:23] [Render thread/INFO]: [CHAT] Bookshelves needed: 5
[23:05:23] [Render thread/INFO]: [CHAT] In slot: 1
[23:05:23] [Render thread/INFO]: [CHAT] Enchantments on item:
[23:05:23] [Render thread/INFO]: [CHAT] - Aqua Affinity

[23:05:24] [Render thread/INFO]: [CHAT] maxExperienceConsumed has been set to 3.

[23:05:27] [Render thread/INFO]: [CHAT] Starting enchantment manipulation. Cancel
[23:05:27] [Render thread/INFO]: [CHAT] Item throws needed: 5 (about 0.25 seconds)
[23:05:27] [Render thread/INFO]: [CHAT] Bookshelves needed: 13
[23:05:27] [Render thread/INFO]: [CHAT] In slot: 3
[23:05:27] [Render thread/INFO]: [CHAT] Enchantments on item:
[23:05:27] [Render thread/INFO]: [CHAT] - Power III
[23:05:27] [Render thread/INFO]: [CHAT] - Aqua Affinity
```

I can rename the config option to `getMaxExperienceLevelConsumed` or something like that but it's becoming pretty long. As you want.