### PR TITLE
Add cfps command

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
+++ b/src/main/java/net/earthcomputer/clientcommands/ClientCommands.java
@@ -151,6 +151,7 @@ public class ClientCommands implements ClientModInitializer {
         FindItemCommand.register(dispatcher, context);
         FishCommand.register(dispatcher, context);
         FovCommand.register(dispatcher);
+        FramerateCommand.register(dispatcher);
         GammaCommand.register(dispatcher);
         GetDataCommand.register(dispatcher);
         GhostBlockCommand.register(dispatcher, context);

--- a/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
@@ -1,0 +1,29 @@
+package net.earthcomputer.clientcommands.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+
+import static com.mojang.brigadier.arguments.IntegerArgumentType.*;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.*;
+
+public class FramerateCommand {
+
+    public static final int MAX_FRAMERATE = Minecraft.getInstance().virtualScreen.screenManager.monitors.values().stream()
+        .mapToInt(monitor -> monitor.getCurrentMode().getRefreshRate())
+        .min().orElseThrow();
+
+    public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
+        dispatcher.register(literal("cfps")
+            .then(argument("maxfps", integer(1, MAX_FRAMERATE))
+                .suggests((context, builder) -> builder.suggest(MAX_FRAMERATE).buildFuture())
+                .executes(ctx -> maxFps(ctx.getSource(), getInteger(ctx, "maxfps")))));
+    }
+
+    private static int maxFps(FabricClientCommandSource source, int maxFps) {
+        source.getClient().getFramerateLimitTracker().setFramerateLimit(maxFps);
+        source.sendFeedback(Component.translatable("commands.cfps.success", maxFps));
+        return maxFps;
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
@@ -5,25 +5,41 @@ import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 
+import java.util.function.IntSupplier;
+
 import static com.mojang.brigadier.arguments.IntegerArgumentType.*;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.*;
 
 public class FramerateCommand {
 
-    public static final int MAX_FRAMERATE = Minecraft.getInstance().virtualScreen.screenManager.monitors.values().stream()
+    public static final IntSupplier MAX_REFRESH_RATE = () -> Minecraft.getInstance().virtualScreen.screenManager.monitors.values().stream()
         .mapToInt(monitor -> monitor.getCurrentMode().getRefreshRate())
-        .min().orElseThrow();
+        .max().orElseThrow();
 
     public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
         dispatcher.register(literal("cfps")
-            .then(argument("maxfps", integer(1, MAX_FRAMERATE))
-                .suggests((context, builder) -> builder.suggest(MAX_FRAMERATE).buildFuture())
-                .executes(ctx -> maxFps(ctx.getSource(), getInteger(ctx, "maxfps")))));
+            .then(argument("maxfps", integer(1))
+                .suggests((context, builder) -> builder.suggest(MAX_REFRESH_RATE.getAsInt()).buildFuture())
+                .executes(ctx -> maxFps(ctx.getSource(), getInteger(ctx, "maxfps"))))
+            .then(literal("unlimited")
+                .executes(ctx -> maxFps(ctx.getSource(), MAX_REFRESH_RATE.getAsInt()))));
     }
 
     private static int maxFps(FabricClientCommandSource source, int maxFps) {
+        int maxRefreshRate = MAX_REFRESH_RATE.getAsInt();
+        boolean unlimited;
+        if (maxFps >= maxRefreshRate) {
+            maxFps = maxRefreshRate;
+            unlimited = true;
+        } else {
+            unlimited = false;
+        }
         source.getClient().getFramerateLimitTracker().setFramerateLimit(maxFps);
-        source.sendFeedback(Component.translatable("commands.cfps.success", maxFps));
+        if (unlimited) {
+            source.sendFeedback(Component.translatable("commands.cfps.unlimited"));
+        } else {
+            source.sendFeedback(Component.translatable("commands.cfps.success", maxFps));
+        }
         return maxFps;
     }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
@@ -19,14 +19,25 @@ public class FramerateCommand {
 
     public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
         dispatcher.register(literal("cfps")
+            .executes(ctx -> getMaxFps(ctx.getSource()))
             .then(argument("maxfps", integer(1))
                 .suggests((context, builder) -> builder.suggest(MAX_REFRESH_RATE.getAsInt()).buildFuture())
-                .executes(ctx -> maxFps(ctx.getSource(), getInteger(ctx, "maxfps"))))
+                .executes(ctx -> setMaxFps(ctx.getSource(), getInteger(ctx, "maxfps"))))
             .then(literal("unlimited")
-                .executes(ctx -> maxFps(ctx.getSource(), MAX_REFRESH_RATE.getAsInt() + 1))));
+                .executes(ctx -> setMaxFps(ctx.getSource(), MAX_REFRESH_RATE.getAsInt() + 1))));
     }
 
-    private static int maxFps(FabricClientCommandSource source, int maxFps) {
+    private static int getMaxFps(FabricClientCommandSource source) {
+        int framerateLimit = source.getClient().getFramerateLimitTracker().getFramerateLimit();
+        if (framerateLimit > MAX_REFRESH_RATE.getAsInt()) {
+            source.sendFeedback(Component.translatable("commands.cfps.getMaxFps.unlimited"));
+        } else {
+            source.sendFeedback(Component.translatable("commands.cfps.getMaxFps", framerateLimit));
+        }
+        return framerateLimit;
+    }
+
+    private static int setMaxFps(FabricClientCommandSource source, int maxFps) {
         int maxRefreshRate = MAX_REFRESH_RATE.getAsInt();
         boolean unlimited;
         if (maxFps > maxRefreshRate) {
@@ -37,9 +48,9 @@ public class FramerateCommand {
         }
         source.getClient().getFramerateLimitTracker().setFramerateLimit(maxFps);
         if (unlimited) {
-            source.sendFeedback(Component.translatable("commands.cfps.unlimited"));
+            source.sendFeedback(Component.translatable("commands.cfps.setMaxFps.unlimited"));
         } else {
-            source.sendFeedback(Component.translatable("commands.cfps.success", maxFps));
+            source.sendFeedback(Component.translatable("commands.cfps.setMaxFps.success", maxFps));
         }
         return maxFps;
     }

--- a/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
@@ -38,16 +38,9 @@ public class FramerateCommand {
     }
 
     private static int setMaxFps(FabricClientCommandSource source, int maxFps) {
-        int maxRefreshRate = MAX_REFRESH_RATE.getAsInt();
-        boolean unlimited;
-        if (maxFps > maxRefreshRate) {
-            maxFps = maxRefreshRate;
-            unlimited = true;
-        } else {
-            unlimited = false;
-        }
         source.getClient().getFramerateLimitTracker().setFramerateLimit(maxFps);
-        if (unlimited) {
+        int maxRefreshRate = MAX_REFRESH_RATE.getAsInt();
+        if (maxFps > maxRefreshRate) {
             source.sendFeedback(Component.translatable("commands.cfps.setMaxFps.unlimited"));
         } else {
             source.sendFeedback(Component.translatable("commands.cfps.setMaxFps.success", maxFps));

--- a/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
@@ -3,6 +3,7 @@ package net.earthcomputer.clientcommands.command;
 import com.mojang.brigadier.CommandDispatcher;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
 import net.minecraft.network.chat.Component;
 
 import java.util.function.IntSupplier;
@@ -12,9 +13,9 @@ import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.*;
 
 public class FramerateCommand {
 
-    public static final IntSupplier MAX_REFRESH_RATE = () -> Minecraft.getInstance().virtualScreen.screenManager.monitors.values().stream()
+    public static final IntSupplier MAX_REFRESH_RATE = () -> Math.max(Options.UNLIMITED_FRAMERATE_CUTOFF, Minecraft.getInstance().virtualScreen.screenManager.monitors.values().stream()
         .mapToInt(monitor -> monitor.getCurrentMode().getRefreshRate())
-        .max().orElseThrow();
+        .max().orElseThrow());
 
     public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
         dispatcher.register(literal("cfps")

--- a/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
+++ b/src/main/java/net/earthcomputer/clientcommands/command/FramerateCommand.java
@@ -23,13 +23,13 @@ public class FramerateCommand {
                 .suggests((context, builder) -> builder.suggest(MAX_REFRESH_RATE.getAsInt()).buildFuture())
                 .executes(ctx -> maxFps(ctx.getSource(), getInteger(ctx, "maxfps"))))
             .then(literal("unlimited")
-                .executes(ctx -> maxFps(ctx.getSource(), MAX_REFRESH_RATE.getAsInt()))));
+                .executes(ctx -> maxFps(ctx.getSource(), MAX_REFRESH_RATE.getAsInt() + 1))));
     }
 
     private static int maxFps(FabricClientCommandSource source, int maxFps) {
         int maxRefreshRate = MAX_REFRESH_RATE.getAsInt();
         boolean unlimited;
-        if (maxFps >= maxRefreshRate) {
+        if (maxFps > maxRefreshRate) {
             maxFps = maxRefreshRate;
             unlimited = true;
         } else {

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/commands/fps/MinecraftMixin.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/commands/fps/MinecraftMixin.java
@@ -1,0 +1,15 @@
+package net.earthcomputer.clientcommands.mixin.commands.fps;
+
+import net.earthcomputer.clientcommands.command.FramerateCommand;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(Minecraft.class)
+public class MinecraftMixin {
+    @ModifyConstant(method = "runTick", constant = @Constant(intValue = 260))
+    private int uncapFps(int original) {
+        return FramerateCommand.MAX_FRAMERATE + 1;
+    }
+}

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/commands/fps/MinecraftMixin.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/commands/fps/MinecraftMixin.java
@@ -11,6 +11,6 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 public class MinecraftMixin {
     @ModifyConstant(method = "runTick", constant = @Constant(intValue = Options.UNLIMITED_FRAMERATE_CUTOFF))
     private int changeCutoff(int original) {
-        return FramerateCommand.MAX_REFRESH_RATE.getAsInt();
+        return FramerateCommand.MAX_REFRESH_RATE.getAsInt() + 1;
     }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/commands/fps/MinecraftMixin.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/commands/fps/MinecraftMixin.java
@@ -10,6 +10,6 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 public class MinecraftMixin {
     @ModifyConstant(method = "runTick", constant = @Constant(intValue = 260))
     private int uncapFps(int original) {
-        return FramerateCommand.MAX_FRAMERATE + 1;
+        return FramerateCommand.MAX_REFRESH_RATE.getAsInt();
     }
 }

--- a/src/main/java/net/earthcomputer/clientcommands/mixin/commands/fps/MinecraftMixin.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/commands/fps/MinecraftMixin.java
@@ -2,14 +2,15 @@ package net.earthcomputer.clientcommands.mixin.commands.fps;
 
 import net.earthcomputer.clientcommands.command.FramerateCommand;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
-    @ModifyConstant(method = "runTick", constant = @Constant(intValue = 260))
-    private int uncapFps(int original) {
+    @ModifyConstant(method = "runTick", constant = @Constant(intValue = Options.UNLIMITED_FRAMERATE_CUTOFF))
+    private int changeCutoff(int original) {
         return FramerateCommand.MAX_REFRESH_RATE.getAsInt();
     }
 }

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -130,6 +130,7 @@
   "commands.cfov.success": "Set FOV to %s",
 
   "commands.cfps.success": "Set max FPS to %s",
+  "commands.cfps.unlimited": "Set max FPS to unlimited",
 
   "commands.cfunction.limitReached": "Command limit (%s) reached",
   "commands.cfunction.success": "Ran %s commands from function %s",

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -129,6 +129,8 @@
 
   "commands.cfov.success": "Set FOV to %s",
 
+  "commands.cfps.success": "Set max FPS to %s",
+
   "commands.cfunction.limitReached": "Command limit (%s) reached",
   "commands.cfunction.success": "Ran %s commands from function %s",
 

--- a/src/main/resources/assets/clientcommands/lang/en_us.json
+++ b/src/main/resources/assets/clientcommands/lang/en_us.json
@@ -129,8 +129,10 @@
 
   "commands.cfov.success": "Set FOV to %s",
 
-  "commands.cfps.success": "Set max FPS to %s",
-  "commands.cfps.unlimited": "Set max FPS to unlimited",
+  "commands.cfps.getMaxFps": "FPS is capped at %s",
+  "commands.cfps.getMaxFps.unlimited": "FPS is unlimited",
+  "commands.cfps.setMaxFps.success": "Set max FPS to %s",
+  "commands.cfps.setMaxFps.unlimited": "Set max FPS to unlimited",
 
   "commands.cfunction.limitReached": "Command limit (%s) reached",
   "commands.cfunction.success": "Ran %s commands from function %s",

--- a/src/main/resources/clientcommands.aw
+++ b/src/main/resources/clientcommands.aw
@@ -17,6 +17,11 @@ accessible method net/minecraft/world/level/block/ShulkerBoxBlock canOpen (Lnet/
 # cfish
 accessible method net/minecraft/world/entity/projectile/FishingHook canHitEntity (Lnet/minecraft/world/entity/Entity;)Z
 
+# cfps
+accessible field net/minecraft/client/Minecraft virtualScreen Lnet/minecraft/client/renderer/VirtualScreen;
+accessible field net/minecraft/client/renderer/VirtualScreen screenManager Lcom/mojang/blaze3d/platform/ScreenManager;
+accessible field com/mojang/blaze3d/platform/ScreenManager monitors Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
+
 # cgive
 accessible method net/minecraft/world/entity/player/Inventory addResource (ILnet/minecraft/world/item/ItemStack;)I
 accessible method net/minecraft/world/entity/player/Inventory hasRemainingSpaceForItem (Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)Z

--- a/src/main/resources/mixins.clientcommands.json
+++ b/src/main/resources/mixins.clientcommands.json
@@ -68,6 +68,7 @@
     "commands.alias.ClientSuggestionProviderMixin",
     "commands.enchant.MultiPlayerGameModeMixin",
     "commands.findblock.ClientLevelMixin",
+    "commands.fps.MinecraftMixin",
     "commands.generic.CommandSuggestionsMixin",
     "commands.glow.LivingEntityRenderStateMixin",
     "commands.reply.ClientPacketListenerMixin",


### PR DESCRIPTION
Closes #711. The unlimited framerate cutoff is now increased to the maximum of the refresh rates of all connected monitors. This allows people to set their maximum framerate to a value possibly higher than `260`, without effectively setting it to unlimited.