### PR TITLE
Enchantment prediction speedup

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/features/EnchantmentCracker.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/EnchantmentCracker.java
@@ -115,6 +115,8 @@ public class EnchantmentCracker {
 
     public static final Logger LOGGER = LogUtils.getLogger();
     private static final int PROGRESS_BAR_WIDTH = 50;
+    private static final LCG LCG_JAVA_ADVANCE_4 = LCG.JAVA.combine(4);
+    private static final int LCG_JAVA_NEXT_INT_OFFSET = LCG.JAVA.getModTrailingZeroes() - 32;
 
     private static WeakReference<LongTask> currentEnchantingTask = null;
     private static boolean isCurrentlyThrowingItems = false;
@@ -395,8 +397,6 @@ public class EnchantmentCracker {
             new ThreadFactoryBuilder().setNameFormat("Enchantment Cracker #%d").build()
         );
 
-        int noDummyXpSeed = Configs.enchCrackState == CrackState.CRACKED ? possibleXPSeeds.firstInt() : 0;
-
         ItemStack stack = new ItemStack(item);
         long playerSeed = PlayerRandCracker.getSeed();
         Registry<Enchantment> enchantmentRegistry = player.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
@@ -404,19 +404,52 @@ public class EnchantmentCracker {
 
         List<CompletableFuture<@Nullable ManipulateResult>> futures = new ArrayList<>();
 
-        for (int i = Configs.enchCrackState == CrackState.CRACKED ? ManipulateResult.NO_DUMMY : 0;
-             i < (Configs.playerCrackState.knowsSeed() ? Configs.getMaxEnchantItemThrows() : 0);
-             i++
+        if (Configs.enchCrackState == CrackState.CRACKED) {
+            int noDummyXpSeed = possibleXPSeeds.firstInt();
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                try {
+                    int[] enchantLevels = new int[3];
+                    RandomSource rand = RandomSource.create();
+                    for (int bookshelvesNeeded = Configs.getMinEnchantBookshelves(); bookshelvesNeeded <= Configs.getMaxEnchantBookshelves(); bookshelvesNeeded++) {
+                        rand.setSeed(noDummyXpSeed);
+                        for (int slot = 0; slot < 3; slot++) {
+                            int level = EnchantmentHelper.getEnchantmentCost(rand, slot, bookshelvesNeeded, stack);
+                            if (level < slot + 1) {
+                                level = 0;
+                            }
+                            enchantLevels[slot] = level;
+                        }
+                        int maxEnchantSlot = Configs.getMaxEnchantSlot();
+                        for (int slot = 0; slot < maxEnchantSlot; slot++) {
+                            List<EnchantmentInstance> enchantments = getEnchantmentList(enchantmentRegistry, rand, noDummyXpSeed, stack, slot, enchantLevels[slot], version);
+                            if (enchantmentsPredicate.test(enchantments)
+                                    && enchantLevels[slot] >= Configs.getMinEnchantLevels()
+                                    && enchantLevels[slot] <= Configs.getMaxEnchantLevels()
+                            ) {
+                                return new ManipulateResult(ManipulateResult.NO_DUMMY, bookshelvesNeeded, slot, enchantments);
+                            }
+                        }
+                    }
+                } catch (Throwable e) {
+                    LOGGER.error("An error occurred simulating enchantments", e);
+                }
+
+                return null;
+            }, threadPool));
+        }
+        Rand playerRand = new Rand(LCG.JAVA, playerSeed);
+        playerRand.nextSeed(); // avoid nextBits(32) calls, replaced by getSeed() >>> (48 - 32)
+        for (int i = 0,
+             maxEnchantItemThrows = Configs.playerCrackState.knowsSeed()
+                     ? Configs.getMaxEnchantItemThrows()
+                     : 0;
+             i < maxEnchantItemThrows;
+             i++, playerRand.advance(LCG_JAVA_ADVANCE_4)
         ) {
+            int xpSeed = (int) (playerRand.getSeed() >>> LCG_JAVA_NEXT_INT_OFFSET);
             int times = i;
             futures.add(CompletableFuture.supplyAsync(() -> {
                 try {
-                    Rand playerRand = new Rand(LCG.JAVA, playerSeed);
-                    playerRand.advance(Math.max(times, 0) * 4L);
-                    int xpSeed = times == ManipulateResult.NO_DUMMY ?
-                        noDummyXpSeed
-                        : (int) playerRand.nextBits(32);
-
                     int[] enchantLevels = new int[3];
                     RandomSource rand = RandomSource.create();
                     for (int bookshelvesNeeded = Configs.getMinEnchantBookshelves(); bookshelvesNeeded <= Configs.getMaxEnchantBookshelves(); bookshelvesNeeded++) {

--- a/src/main/java/net/earthcomputer/clientcommands/features/EnchantmentCracker.java
+++ b/src/main/java/net/earthcomputer/clientcommands/features/EnchantmentCracker.java
@@ -5,6 +5,8 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.logging.LogUtils;
 import com.seedfinding.mcseed.lcg.LCG;
 import com.seedfinding.mcseed.rand.Rand;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.earthcomputer.clientcommands.Configs;
@@ -55,8 +57,6 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -148,7 +148,7 @@ public class EnchantmentCracker {
         lines.add(Component.empty());
 
         if (crackState == CrackState.CRACKED) {
-            lines.add(Component.translatable("enchCrack.xpSeed.one", String.format("%08X", possibleXPSeeds.iterator().next())));
+            lines.add(Component.translatable("enchCrack.xpSeed.one", String.format("%08X", possibleXPSeeds.firstInt())));
         } else if (crackState == CrackState.CRACKING) {
             lines.add(Component.translatable("enchCrack.xpSeed.many", possibleXPSeeds.size()));
         }
@@ -204,7 +204,7 @@ public class EnchantmentCracker {
      * This section is in charge of the logic of the cracking
      */
 
-    static Set<Integer> possibleXPSeeds = new HashSet<>(1 << 20);
+    static IntLinkedOpenHashSet possibleXPSeeds = new IntLinkedOpenHashSet(1 << 20);
     private static int firstXpSeed;
     public static BlockPos enchantingTablePos = null;
     private static boolean doneEnchantment = false;
@@ -255,9 +255,9 @@ public class EnchantmentCracker {
         int version = MultiVersionCompat.INSTANCE.getProtocolVersion();
 
         // brute force the possible seeds
-        Iterator<Integer> xpSeedItr = possibleXPSeeds.iterator();
+        IntIterator xpSeedItr = possibleXPSeeds.iterator();
         seedLoop: while (xpSeedItr.hasNext()) {
-            int xpSeed = xpSeedItr.next();
+            int xpSeed = xpSeedItr.nextInt();
             rand.setSeed(xpSeed);
 
             // check enchantment levels match
@@ -302,7 +302,7 @@ public class EnchantmentCracker {
                     "Invalid enchantment seed information. Has the server got unknown mods, is there a desync, or is the client just bugged?");
         } else if (possibleXPSeeds.size() == 1) {
             Configs.enchCrackState = CrackState.CRACKED;
-            addPlayerRNGInfo(possibleXPSeeds.iterator().next());
+            addPlayerRNGInfo(possibleXPSeeds.firstInt());
         }
     }
 
@@ -395,7 +395,7 @@ public class EnchantmentCracker {
             new ThreadFactoryBuilder().setNameFormat("Enchantment Cracker #%d").build()
         );
 
-        int noDummyXpSeed = Configs.enchCrackState == CrackState.CRACKED ? possibleXPSeeds.iterator().next() : 0;
+        int noDummyXpSeed = Configs.enchCrackState == CrackState.CRACKED ? possibleXPSeeds.firstInt() : 0;
 
         ItemStack stack = new ItemStack(item);
         long playerSeed = PlayerRandCracker.getSeed();
@@ -698,7 +698,7 @@ public class EnchantmentCracker {
         } else {
             // return the enchantments using our cracked seed
             RandomSource rand = RandomSource.create();
-            int xpSeed = possibleXPSeeds.iterator().next();
+            int xpSeed = possibleXPSeeds.firstInt();
             ItemStack enchantingStack = enchMenu.getSlot(0).getItem();
             int enchantLevels = enchMenu.costs[slot];
             return getEnchantmentList(enchantmentRegistry, rand, xpSeed, enchantingStack, slot, enchantLevels, MultiVersionCompat.INSTANCE.getProtocolVersion());


### PR DESCRIPTION
I conducted a performance comparison between my custom build and the official build.

Test Parameters:

Command: /cenchant minecraft:diamond_boots with minecraft:feather_falling 4 with minecraft:protection 4
Configuration: maxEnchantItemThrows=50000
Results:

My Custom Build: 3-5 seconds
Official Build: 10+ seconds
I have a couple of questions regarding potential optimizations:

In a loop, can RandomSource.create() be safely replaced with RandomSource.createNewThreadLocalInstance()?
When I increased the test parameters to maxEnchantItemThrows=100000, my build experienced significant FPS spikes, and the task took over 15 seconds to complete. Should I consider reducing the thread pool size to address this?