### PR TITLE
fix crash on saving overworld.dat

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/util/DebugRandom.java
+++ b/src/main/java/net/earthcomputer/clientcommands/util/DebugRandom.java
@@ -124,7 +124,7 @@ public class DebugRandom extends LegacyRandomSource {
         super(RandomSupport.generateUniqueSeed());
 
         this.tagToSaveSupplier = CompoundTag::new;
-        this.idSupplier = () -> level.dimension().location().toString();
+        this.idSupplier = () -> level.dimension().location().getPath();
 
         this.stackTraces.add(this.stackTracesThisTick);
         try {


### PR DESCRIPTION
For me saving e.g. overworld.dat with -Dclientcommands.debugDimensionRng=overworld as I was told on quitting a world crashes without this fix on windows 11, because windows doesn't allow colon (":") in file paths and .toString gives "minecraft:overworld"