### PR TITLE
Disable debug variable printing

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/mixin/commands/render/LevelExtractorMixin.java
+++ b/src/main/java/net/earthcomputer/clientcommands/mixin/commands/render/LevelExtractorMixin.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(LevelExtractor.class)
 public class LevelExtractorMixin {
     @Inject(method = "isEntityVisible", at = @At("RETURN"), cancellable = true)
-    private void hasIndirectPassengersAndClientCommandsShouldRender(CallbackInfoReturnable<Boolean> cir, @Local(name = "entity", argsOnly = true, print = true) Entity entity) {
+    private void hasIndirectPassengersAndClientCommandsShouldRender(CallbackInfoReturnable<Boolean> cir, @Local(name = "entity", argsOnly = true) Entity entity) {
         if (cir.getReturnValueZ() && !RenderSettings.shouldRenderEntity(entity)) {
             cir.setReturnValue(false);
         }


### PR DESCRIPTION
Removes a left over `print = true`, which was dumping a bunch of info into the logs and aborts the injection.