### PR TITLE
Don't assume a level render state exists during extraction

### DIFF
--- a/src/main/java/net/earthcomputer/clientcommands/render/RenderQueue.java
+++ b/src/main/java/net/earthcomputer/clientcommands/render/RenderQueue.java
@@ -55,6 +55,12 @@ public class RenderQueue {
         ClientTickEvents.START_CLIENT_TICK.register(RenderQueue::tick);
 
         LevelExtractionEvents.END_EXTRACTION.register(context -> {
+            // Mods that render a secondary world (e.g. Immersive Portals' portal
+            // destination pass) run extraction with no level render state.
+            if (context.levelState() == null) {
+                return;
+            }
+
             EnumMap<Layer, List<Shape.RenderState>> renderStates = new EnumMap<>(Layer.class);
             queue.forEach((layer, shapes) -> {
                 List<Shape.RenderState> states = new ArrayList<>();
@@ -131,6 +137,10 @@ public class RenderQueue {
     }
 
     private static void render(Layer layer, RenderType renderType, LevelRenderContext context) {
+        if (context.levelState() == null) {
+            return;
+        }
+
         EnumMap<Layer, List<Shape.RenderState>> renderStates = context.levelState().getData(RENDER_STATES_KEY);
         if (renderStates == null) {
             return;


### PR DESCRIPTION
Fixes #811.

`RenderQueue`'s `END_EXTRACTION` handler assumes `LevelExtractionContext#levelState`
is non-null. Immersive Portals runs a second extraction pass for a portal's
destination world from `SecondaryWorldRenderCore.renderDestWorld`, and that pass has
no level render state — so the handler NPEs and the game crashes the moment a portal
is on screen.

This skips the extraction when there is no level state. The shapes simply aren't
collected for the secondary pass and still render normally in the main view; the only
visible consequence is that clientcommands' overlays don't draw *inside* a portal view.

The same guard is added to `render()` for symmetry, but I want to flag that I could
not get it to trigger — `LevelRenderContext#levelState` stayed non-null through every
portal pass I observed. Happy to drop that half if you'd rather keep it minimal.

### Testing

Built this against 26.2 and played with Seamless Portals (Immersive Portals engine)
for a while: no crash, portals still render see-through with stock Immersive Portals
config, and `/cenchant` works end to end (RNG cracked, enchantment manipulation,
seed ready).

To be sure nothing else was in play, I diffed the resulting jar against the released
2.15.1 artifact — only `RenderQueue*.class` and `build_info.json` differ, the other
1293 entries are byte-identical.

Reproduction, full stack trace, and a note about the same unguarded call in the
bundled `simplewaypoints` are in #811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LE8JscQsjVStsxdM6WcJV
